### PR TITLE
Refactor `resolve_reference_paths`

### DIFF
--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -68,10 +68,7 @@ impl SliceConfig {
     // Resolve reference URIs to file paths to be used by the Slice compiler.
     pub fn resolve_reference_paths(&self) -> Vec<String> {
         // If `root_uri` isn't set, or doesn't represent a valid file path, path resolution is impossible, so we return.
-        let Some(root_uri) = &self.root_uri else {
-            return vec![];
-        };
-        let Ok(root_path) = root_uri.to_file_path() else {
+        let Some(Ok(root_path)) = self.root_uri.as_ref().map(Url::to_file_path) else {
             return vec![];
         };
 

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -71,21 +71,23 @@ impl SliceConfig {
             return None;
         };
 
+        // If no references are set, default to using the root_uri.
+        let Some(references) = &self.references else {
+            return Some(vec![root_uri.clone()]);
+        };
+
         // Convert the root_uri to a file path
         let root_path = root_uri
             .to_file_path()
             .ok()?;
 
         // Convert reference directories to URLs or use root_uri if none are present
-        let result_urls = match self.references.as_ref() {
-            Some(dirs) => dirs
-                .iter()
-                .map(|dir| {
-                    Url::from_file_path(root_path.join(dir)).ok()
-                })
-                .collect::<Option<Vec<_>>>()?,
-            None => vec![root_uri.clone()],
-        };
+        let result_urls = references
+            .iter()
+            .map(|dir| {
+                Url::from_file_path(root_path.join(dir)).ok()
+            })
+            .collect::<Option<Vec<_>>>()?;
 
         Some(result_urls)
     }

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -66,27 +66,26 @@ impl SliceConfig {
     }
 
     // Convert reference directory strings into URLs.
-    fn try_get_reference_urls(&self) -> Result<Vec<Url>, ()> {
+    fn try_get_reference_urls(&self) -> Option<Vec<Url>> {
         // Convert the root_uri to a file path
         let root_path = self
             .root_uri
-            .as_ref()
-            .ok_or(())?
+            .as_ref()?
             .to_file_path()
-            .map_err(|_| ())?;
+            .ok()?;
 
         // Convert reference directories to URLs or use root_uri if none are present
         let result_urls = match self.references.as_ref() {
             Some(dirs) => dirs
                 .iter()
                 .map(|dir| {
-                    Url::from_file_path(root_path.join(dir)).map_err(|_| ())
+                    Url::from_file_path(root_path.join(dir)).ok()
                 })
-                .collect::<Result<Vec<_>, _>>()?,
-            None => vec![self.root_uri.clone().ok_or(())?],
+                .collect::<Option<Vec<_>>>()?,
+            None => vec![self.root_uri.clone()?],
         };
 
-        Ok(result_urls)
+        Some(result_urls)
     }
 
     // Resolve reference URIs to file paths to be used by the Slice compiler.

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -79,7 +79,7 @@ impl SliceConfig {
         let Some(references) = &self.references else {
             let default_path = match root_path.is_absolute() {
                 true => root_path.display().to_string(),
-                false => root_path.join(&root_path).display().to_string(), // Is joining a path to itself correct?
+                false => root_path.join(&root_path).display().to_string(),
             };
             return vec![default_path];
         };

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -66,20 +66,20 @@ impl SliceConfig {
     }
 
     // Convert reference directory strings into URLs.
-    fn try_get_reference_urls(&self) -> Option<Vec<Url>> {
+    fn try_get_reference_urls(&self) -> Vec<Url> {
         // If no root_uri is set, return `None`, since this won't be able to resolve the reference urls.
         let Some(root_uri) = &self.root_uri else {
-            return None;
+            return vec![];
         };
 
         // If no references are set, default to using the root_uri.
         let Some(references) = &self.references else {
-            return Some(vec![root_uri.clone()]);
+            return vec![root_uri.clone()];
         };
 
         // Convert the root_uri to a file path. If it fails, return `None`.
         let Ok(root_path) = root_uri.to_file_path() else {
-            return None;
+            return vec![];
         };
 
         // Convert reference directories to URLs or use root_uri if none are present
@@ -87,16 +87,15 @@ impl SliceConfig {
         for reference in references {
             match Url::from_file_path(root_path.join(reference)) {
                 Ok(full_path) => result_urls.push(full_path),
-                Err(_) => return None,
+                Err(_) => return vec![],
             }
         }
-
-        Some(result_urls)
+        result_urls
     }
 
     // Resolve reference URIs to file paths to be used by the Slice compiler.
     pub fn resolve_reference_paths(&self) -> Vec<String> {
-        let reference_urls: Vec<Url> = self.try_get_reference_urls().unwrap_or_default();
+        let reference_urls = self.try_get_reference_urls();
 
         // If no reference directories are set, use the root_uri as the reference directory.
         if reference_urls.is_empty() {

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -67,10 +67,12 @@ impl SliceConfig {
 
     // Convert reference directory strings into URLs.
     fn try_get_reference_urls(&self) -> Option<Vec<Url>> {
+        let Some(root_uri) = &self.root_uri else {
+            return None;
+        };
+
         // Convert the root_uri to a file path
-        let root_path = self
-            .root_uri
-            .as_ref()?
+        let root_path = root_uri
             .to_file_path()
             .ok()?;
 
@@ -82,7 +84,7 @@ impl SliceConfig {
                     Url::from_file_path(root_path.join(dir)).ok()
                 })
                 .collect::<Option<Vec<_>>>()?,
-            None => vec![self.root_uri.clone()?],
+            None => vec![root_uri.clone()],
         };
 
         Some(result_urls)


### PR DESCRIPTION
This PR refactors the stated function. No logic of any kind should be modified by this PR, it just reorganizes the code and adds some explanatory comments for readability.

Many of the function chains included repetitive checks for whether an option was `Some`, or some conversion succeeded.
Instead of doing these over and over, they were transformed into `let-else` guards we do at the top of the function.

There's 2 places I suspect could be further improved, but would be altering logic:
----

We have this line: `root_path.join(&root_path).display().to_string()` which joins the root_uri to itself.
That's either no-op or totally broken right? Or is this necessary to fix some weird pathing problem.

In the original code, this happened when `self.references = None`. So `try_get_reference_urls` returns `root_uri` as a default.
But the code in `resolve_reference_paths` ALWAYS calls `root_path.join(path)`, even when path was defaulted to `root_path`.
It was impossible to see this oddity before refactoring.

----

In some parts of the server, we seem to rely on `root_uri` being an absolute path, but in other places (this function) we guard against it being relative. Do we have any guarantees about this? Either it's guaranteed and these checks are dead code, or we should always be checking if it's relative.

---

Also, `try_get_reference_urls` used to return some helpful error messages, but then the function that calls it just always did `unwrap_or_default()`, throwing these errors away. It's not clear to me that those cases were actually _errors_, or just some config wasn't set or something (which is valid to do).