### PR TITLE
SliceConfig Cleanup

### DIFF
--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -7,11 +7,15 @@ use tower_lsp::{
 
 #[derive(Default, Debug)]
 pub struct SliceConfig {
-    pub references: Option<Vec<String>>,
-    pub root_uri: Option<Url>,
+    references: Option<Vec<String>>,
+    root_uri: Option<Url>,
 }
 
 impl SliceConfig {
+    pub fn set_root_uri(&mut self, root: Url) {
+        self.root_uri = Some(root);
+    }
+
     pub fn try_update_from_params(&mut self, params: &DidChangeConfigurationParams) {
         self.references = Self::parse_reference_directories(params);
     }

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -12,12 +12,8 @@ pub struct SliceConfig {
 }
 
 impl SliceConfig {
-    pub async fn try_update_from_params(
-        &mut self,
-        params: &DidChangeConfigurationParams,
-    ) -> tower_lsp::jsonrpc::Result<()> {
+    pub fn try_update_from_params(&mut self, params: &DidChangeConfigurationParams) {
         self.references = Self::parse_reference_directories(params);
-        Ok(())
     }
 
     pub async fn try_update_from_client(

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -128,13 +128,8 @@ impl LanguageServer for Backend {
 
         // Update the slice configuration
         {
-            // TODO: Log error
-            let _ = self
-                .slice_config
-                .lock()
-                .await
-                .try_update_from_params(&params)
-                .await;
+            let mut slice_config = self.slice_config.lock().await;
+            slice_config.try_update_from_params(&params);
         }
 
         // Store the current files in the compilation state before re-compiling

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -55,10 +55,8 @@ impl LanguageServer for Backend {
             .and_then(|uri| uri.to_file_path().ok())
             .and_then(|path| Url::from_file_path(path).ok())
         {
-            *self.slice_config.lock().await = SliceConfig {
-                root_uri: Some(root_uri.clone()),
-                ..Default::default()
-            }
+            let mut slice_config = self.slice_config.lock().await;
+            slice_config.set_root_uri(root_uri.clone());
         }
 
         Ok(InitializeResult {


### PR DESCRIPTION
This PR makes the fields of SliceConfig private, so it's easier to reason about when these fields can be updated.
Interestingly, we never read these fields directly anyways, and we only set them in one place (which is simplified by this).

It also simplifies `try_update_from_params`. This function wasn't `async` and always returned `Ok`. So I removed `async` and the `Result` error type.

----

These changes are because I'd like to cache our path resolution.
Right now we always re-compute them, but we only actually need to recompute when the config changes.