### PR TITLE
Make built-in References an Option

### DIFF
--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -15,7 +15,7 @@ pub struct SliceConfig {
 }
 
 impl SliceConfig {
-    // Path must be absolute.
+    // root must be absolute.
     pub fn set_root_uri(&mut self, root: Url) {
         self.root_uri = Some(root);
         self.refresh_reference_paths();

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -63,7 +63,7 @@ impl LanguageServer for Backend {
                 options.get("builtInSlicePath").and_then(|v| v.as_str())
             {
                 let mut slice_config = self.slice_config.lock().await;
-                slice_config.set_built_in_reference(built_in_slice_path.to_owned());
+                slice_config.set_built_in_reference_path(built_in_slice_path.to_owned());
             }
         }
 


### PR DESCRIPTION
Currently, when the server starts up, we create a default `SliceConfig`.
This means that `built_in_slice_path` gets a default value of `""`.

If for some reason, this property isn't set yet, this will cause the extensions to search `/slice/` for files, which will break.

Instead, it's safer to use an `Option` and only add it if it's set.
And then it has a default value of `None`.
Note, that this is what we do for the other paths in `SliceConfig`.

---

Also, it simplifies some logic under the assumption that `root_uri` is absolute.
Guess I forgot to add this to my other PR, or maybe it got lost in the merge.