### PR TITLE
Remove 'Arc' wrapper, and Decouple 'session' and 'client'.

### DIFF
--- a/server/src/session.rs
+++ b/server/src/session.rs
@@ -2,7 +2,10 @@
 
 use crate::configuration_set::ConfigurationSet;
 use tokio::sync::{Mutex, RwLock};
-use tower_lsp::{lsp_types::{ConfigurationItem, DidChangeConfigurationParams, Url}, Client};
+use tower_lsp::{
+    lsp_types::{ConfigurationItem, DidChangeConfigurationParams, Url},
+    Client,
+};
 
 pub struct Session {
     /// This vector contains all of the configuration sets for the language server. Each element is a tuple containing

--- a/server/src/session.rs
+++ b/server/src/session.rs
@@ -2,10 +2,9 @@
 
 use crate::configuration_set::ConfigurationSet;
 use tokio::sync::{Mutex, RwLock};
-use tower_lsp::lsp_types::{ConfigurationItem, DidChangeConfigurationParams, Url};
+use tower_lsp::{lsp_types::{ConfigurationItem, DidChangeConfigurationParams, Url}, Client};
 
 pub struct Session {
-    client: tower_lsp::Client,
     /// This vector contains all of the configuration sets for the language server. Each element is a tuple containing
     /// `SliceConfig` and `CompilationState`. The `SliceConfig` is used to determine which configuration set to use when
     /// publishing diagnostics. The `CompilationState` is used to retrieve the diagnostics for a given file.
@@ -17,9 +16,8 @@ pub struct Session {
 }
 
 impl Session {
-    pub fn new(client: tower_lsp::Client) -> Self {
+    pub fn new() -> Self {
         Self {
-            client,
             configuration_sets: Mutex::new(Vec::new()),
             root_uri: RwLock::new(None),
             built_in_slice_path: RwLock::new(String::new()),
@@ -52,7 +50,7 @@ impl Session {
     }
 
     // Update the stored configuration sets by fetching them from the client.
-    pub async fn fetch_configurations(&self) {
+    pub async fn fetch_configurations(&self, client: &Client) {
         let built_in_path = &self.built_in_slice_path.read().await;
         let root_uri_guard = self.root_uri.read().await;
         let root_uri = (*root_uri_guard).clone().expect("root_uri not set");
@@ -63,8 +61,7 @@ impl Session {
         }];
 
         // Fetch the configurations from the client and parse them.
-        let configurations = self
-            .client
+        let configurations = client
             .configuration(params)
             .await
             .ok()


### PR DESCRIPTION
This small PR removes the `Arc` wrapper around `Session`.
`Arc` is for shared ownership, but there is only a single owner for `Session`s, the `Backend`.

I opened a PR to make sure there isn't some unintended consequence to removing this wrapper.
Without `Arc`, it's now possible to get mutable references to the `Session`.

It also removes a back-reference where `Session` held a reference to the `Client` it was created from.
But this is minor.