### PR TITLE
Simplify and Centralize `root_uri` and `built_in_slice_path`

### DIFF
--- a/server/src/configuration_set.rs
+++ b/server/src/configuration_set.rs
@@ -3,7 +3,6 @@
 use crate::slice_config;
 use slice_config::SliceConfig;
 use slicec::compilation_state::CompilationState;
-use tower_lsp::lsp_types::Url;
 
 #[derive(Debug)]
 pub struct ConfigurationSet {
@@ -12,11 +11,9 @@ pub struct ConfigurationSet {
 }
 
 impl ConfigurationSet {
-    /// Creates a new `ConfigurationSet` using the given root URI and built-in path.
-    pub fn new(root_uri: Url, built_in_path: String) -> Self {
+    /// Creates a new `ConfigurationSet`.
+    pub fn new() -> Self {
         let mut slice_config = SliceConfig::default();
-        slice_config.set_root_uri(root_uri);
-        slice_config.set_built_in_path(built_in_path.to_owned());
         let compilation_state =
             slicec::compile_from_options(slice_config.as_slice_options(), |_| {}, |_| {});
         Self {
@@ -26,27 +23,21 @@ impl ConfigurationSet {
     }
 
     /// Parses a vector of `ConfigurationSet` from a JSON array, root URI, and built-in path.
-    pub fn parse_configuration_sets(
-        config_array: &[serde_json::Value],
-        root_uri: &Url,
-        built_in_path: &str,
-    ) -> Vec<ConfigurationSet> {
+    pub fn parse_configuration_sets(config_array: &[serde_json::Value]) -> Vec<ConfigurationSet> {
         config_array
             .iter()
-            .map(|value| ConfigurationSet::from_json(value, root_uri, built_in_path))
-            .collect::<Vec<_>>()
+            .map(ConfigurationSet::from_json)
+            .collect::<_>()
     }
 
     /// Constructs a `ConfigurationSet` from a JSON value.
-    fn from_json(value: &serde_json::Value, root_uri: &Url, built_in_path: &str) -> Self {
+    fn from_json(value: &serde_json::Value) -> Self {
         // Parse the paths and `include_built_in_types` from the configuration set
         let paths = parse_paths(value);
         let include_built_in = parse_include_built_in(value);
 
         // Create the SliceConfig and CompilationState
         let mut slice_config = SliceConfig::default();
-        slice_config.set_root_uri(root_uri.clone());
-        slice_config.set_built_in_path(built_in_path.to_owned());
         slice_config.update_from_paths(paths);
         slice_config.update_include_built_in_path(include_built_in);
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -23,7 +23,7 @@ mod utils;
 static SERVER_CONFIG: OnceLock<ServerConfig> = OnceLock::new();
 
 pub fn server_config() -> &'static ServerConfig {
-    SERVER_CONFIG.get().expect("server failed to initialized: `server_config` is unset!")
+    SERVER_CONFIG.get().expect("server failed to initialize: `server_config` is unset!")
 }
 
 #[tokio::main]

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -23,9 +23,7 @@ mod utils;
 static SERVER_CONFIG: OnceLock<ServerConfig> = OnceLock::new();
 
 pub fn server_config() -> &'static ServerConfig {
-    SERVER_CONFIG
-        .get()
-        .expect("server failed to initialized: `server_config` is unset!")
+    SERVER_CONFIG.get().expect("server failed to initialized: `server_config` is unset!")
 }
 
 #[tokio::main]
@@ -66,13 +64,8 @@ impl Backend {
             .and_then(|v| v.as_str().map(str::to_owned))
             .expect("builtInSlicePath not found in initialization options");
 
-        let server_config = ServerConfig {
-            root_uri,
-            built_in_slice_path,
-        };
-        SERVER_CONFIG
-            .set(server_config)
-            .expect("server is already initialized: `server_config` is set!");
+        let server_config = ServerConfig { root_uri, built_in_slice_path };
+        SERVER_CONFIG.set(server_config).expect("server is already initialized: `server_config` is set!");
     }
 
     pub fn capabilities() -> ServerCapabilities {

--- a/server/src/session.rs
+++ b/server/src/session.rs
@@ -1,9 +1,9 @@
 // Copyright (c) ZeroC, Inc.
 
 use crate::configuration_set::ConfigurationSet;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::Mutex;
 use tower_lsp::{
-    lsp_types::{ConfigurationItem, DidChangeConfigurationParams, Url},
+    lsp_types::{ConfigurationItem, DidChangeConfigurationParams},
     Client,
 };
 
@@ -12,52 +12,17 @@ pub struct Session {
     /// `SliceConfig` and `CompilationState`. The `SliceConfig` is used to determine which configuration set to use when
     /// publishing diagnostics. The `CompilationState` is used to retrieve the diagnostics for a given file.
     pub configuration_sets: Mutex<Vec<ConfigurationSet>>,
-    /// This is the root URI of the workspace. It is used to resolve relative paths in the configuration.
-    pub root_uri: RwLock<Option<Url>>,
-    /// This is the path to the built-in Slice files that are included with the extension.
-    pub built_in_slice_path: RwLock<String>,
 }
 
 impl Session {
     pub fn new() -> Self {
         Self {
             configuration_sets: Mutex::new(Vec::new()),
-            root_uri: RwLock::new(None),
-            built_in_slice_path: RwLock::new(String::new()),
         }
-    }
-
-    // Update the properties of the session from `InitializeParams`
-    pub async fn update_from_initialize_params(
-        &self,
-        params: tower_lsp::lsp_types::InitializeParams,
-    ) {
-        // This is the path to the built-in Slice files that are included with the extension. It should always
-        // be present.
-        let built_in_slice_path = params
-            .initialization_options
-            .and_then(|opts| opts.get("builtInSlicePath").cloned())
-            .and_then(|v| v.as_str().map(str::to_owned))
-            .expect("builtInSlicePath not found in initialization options");
-        *self.built_in_slice_path.write().await = built_in_slice_path;
-
-        // Use the root_uri if it exists temporarily as we cannot access configuration until
-        // after initialization. Additionally, LSP may provide the windows path with escaping or a lowercase
-        // drive letter. To fix this, we convert the path to a URL and then back to a path.
-        let root_uri = params
-            .root_uri
-            .and_then(|uri| uri.to_file_path().ok())
-            .and_then(|path| Url::from_file_path(path).ok())
-            .expect("root_uri not found in initialization parameters");
-        *self.root_uri.write().await = Some(root_uri);
     }
 
     // Update the stored configuration sets by fetching them from the client.
     pub async fn fetch_configurations(&self, client: &Client) {
-        let built_in_path = &self.built_in_slice_path.read().await;
-        let root_uri_guard = self.root_uri.read().await;
-        let root_uri = (*root_uri_guard).clone().expect("root_uri not set");
-
         let params = vec![ConfigurationItem {
             scope_uri: None,
             section: Some("slice.configurations".to_string()),
@@ -75,7 +40,7 @@ impl Session {
                     .flatten()
                     .cloned()
                     .collect::<Vec<_>>();
-                ConfigurationSet::parse_configuration_sets(config_array, &root_uri, built_in_path)
+                ConfigurationSet::parse_configuration_sets(config_array)
             })
             .unwrap_or_default();
 
@@ -85,17 +50,13 @@ impl Session {
 
     // Update the configuration sets from the `DidChangeConfigurationParams` notification.
     pub async fn update_configurations_from_params(&self, params: DidChangeConfigurationParams) {
-        let built_in_path = &self.built_in_slice_path.read().await;
-        let root_uri_guard = self.root_uri.read().await;
-        let root_uri = (*root_uri_guard).clone().expect("root_uri not set");
-
         // Parse the configurations from the notification
         let configurations = params
             .settings
             .get("slice")
             .and_then(|v| v.get("configurations"))
             .and_then(|v| v.as_array())
-            .map(|arr| ConfigurationSet::parse_configuration_sets(arr, &root_uri, built_in_path))
+            .map(|arr| ConfigurationSet::parse_configuration_sets(arr))
             .unwrap_or_default();
 
         // Update the configuration sets
@@ -107,11 +68,7 @@ impl Session {
     async fn update_configurations(&self, mut configurations: Vec<ConfigurationSet>) {
         // Insert the default configuration set if needed
         if configurations.is_empty() {
-            let root_uri = self.root_uri.read().await;
-            let built_in_slice_path = self.built_in_slice_path.read().await;
-            let default =
-                ConfigurationSet::new(root_uri.clone().unwrap(), built_in_slice_path.clone());
-            configurations.push(default);
+            configurations.push(ConfigurationSet::new());
         }
 
         let mut configuration_sets = self.configuration_sets.lock().await;

--- a/server/src/slice_config.rs
+++ b/server/src/slice_config.rs
@@ -3,41 +3,37 @@
 use slicec::slice_options::SliceOptions;
 use tower_lsp::lsp_types::Url;
 
+#[derive(Debug)]
+pub struct ServerConfig {
+    /// This is the root URI of the workspace. It is used to resolve relative paths in the configuration.
+    pub root_uri: Url,
+    /// This is the path to the built-in Slice files that are included with the extension.
+    pub built_in_slice_path: String,
+}
+
 // This struct holds the configuration for a single compilation set.
 #[derive(Default, Debug)]
 pub struct SliceConfig {
     paths: Option<Vec<String>>,
-    root_uri: Option<Url>,
     include_built_in_path: bool,
-    built_in_slice_path: String,
-    cached_slice_options: SliceOptions,
+    cached_slice_options: Option<SliceOptions>,
 }
 
 impl SliceConfig {
-    pub fn set_root_uri(&mut self, root: Url) {
-        self.root_uri = Some(root);
-        self.refresh_paths();
-    }
-
-    pub fn set_built_in_path(&mut self, path: String) {
-        self.built_in_slice_path = path;
-        self.refresh_paths();
-    }
-
     pub fn update_from_paths(&mut self, paths: Vec<String>) {
         self.paths = Some(paths);
-        self.refresh_paths();
+        self.cached_slice_options = None; // Invalidate the cache so it gets regenerated.
     }
 
     pub fn update_include_built_in_path(&mut self, include: bool) {
         self.include_built_in_path = include;
-        self.refresh_paths();
+        self.cached_slice_options = None; // Invalidate the cache so it gets regenerated.
     }
 
     // Resolve path URIs to file paths to be used by the Slice compiler.
-    fn resolve_paths(&self) -> Vec<String> {
-        // If `root_uri` isn't set, or doesn't represent a valid file path, path resolution is impossible, so we return.
-        let Some(Ok(root_path)) = self.root_uri.as_ref().map(Url::to_file_path) else {
+    fn resolve_paths(&self, server_config: &ServerConfig) -> Vec<String> {
+        // If `root_uri` doesn't represent a valid file path, path resolution is impossible, so we return.
+        let Ok(root_path) = Url::to_file_path(&server_config.root_uri) else {
             return vec![];
         };
 
@@ -83,18 +79,19 @@ impl SliceConfig {
         // Add the well known types path to the end of the list.
         // TODO: Weird case where `include_built_in_path` is true but `built_in_slice_path` is empty.
         // We should probably handle this case better or make sure it never happens.
-        if self.include_built_in_path && !self.built_in_slice_path.is_empty() {
-            paths.push(self.built_in_slice_path.clone());
+        if self.include_built_in_path && !server_config.built_in_slice_path.is_empty() {
+            paths.push(server_config.built_in_slice_path.clone());
         }
         paths
     }
 
-    pub fn as_slice_options(&self) -> &SliceOptions {
-        &self.cached_slice_options
-    }
+    pub fn as_slice_options(&mut self) -> &SliceOptions {
+        if self.cached_slice_options.is_none() {
+            let mut slice_options = SliceOptions::default();
+            slice_options.references = self.resolve_paths(crate::server_config());
+            self.cached_slice_options = Some(slice_options);
+        }
 
-    // This function should be called whenever the configuration changes.
-    fn refresh_paths(&mut self) {
-        self.cached_slice_options.references = self.resolve_paths();
+        self.cached_slice_options.as_ref().unwrap()
     }
 }


### PR DESCRIPTION
This PR centralizes the server-level config into their own struct: `ServerConfig`.
These fields are `root_uri` and `built_in_slice_path`.

And places an instance of this struct in a global `OnceLock`.
`OnceLock` has the semantics that it can only be set once, and is set atomically.

It also slightly tweaks how the `SliceConfig` caching works.
Now we update the cache when it's used, instead of whenever we change a value. This should trigger less cache updates.

----

Before this PR, we stored these fields directly in `Session`, behind `RwLocks`.
We also stored copies of these in every `SliceConfig`, but as bare values. All of these we redundant, and removed.