### PR TITLE
Move All Configuration Loading into `initialize`

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -150,6 +150,9 @@ export async function activate(context: ExtensionContext) {
 
     const serverOptions: ServerOptions = { run, debug: run };
 
+    const config = workspace.getConfiguration("slice");
+    const configuration_sets = config.get<any[]>("configurations");
+
     // Configure the language client options.
     const clientOptions: LanguageClientOptions = {
       documentSelector: [{ scheme: "file", language: "slice" }],
@@ -161,6 +164,7 @@ export async function activate(context: ExtensionContext) {
       revealOutputChannelOn: RevealOutputChannelOn.Never,
       initializationOptions: {
         builtInSlicePath: builtInSlicePath,
+        configurations: configuration_sets,
       },
     };
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -87,7 +87,7 @@ impl LanguageServer for Backend {
     }
 
     async fn initialized(&self, _: InitializedParams) {
-        // We wait until after the server and client are fully initialized to publish any diagnostics we've found.
+        // Now that the server and client are fully initialized, it's safe to publish any diagnostics we've found.
         publish_diagnostics(&self.client, &self.session.configuration_sets).await;
     }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -87,11 +87,7 @@ impl LanguageServer for Backend {
     }
 
     async fn initialized(&self, _: InitializedParams) {
-        // Update the configuration sets by fetching the configurations from the client. This is performed after
-        // initialization because the client may not be ready to provide configurations before initialization.
-        self.session.fetch_configurations(&self.client).await;
-
-        // Publish the diagnostics for all files
+        // We wait until after the server and client are fully initialized to publish any diagnostics we've found.
         publish_diagnostics(&self.client, &self.session.configuration_sets).await;
     }
 


### PR DESCRIPTION
This PR simplifies the server's initialization process.

Initialization starts when the client sends an `initialize` request, the server responds, and finally the client sends `initialized` to acknowledge everything is good to go.

But the initialization of our server is split between these two functions.
We pass in some of the config during `initialize`, then in `initialized` we request the remaining configuration from the client.

This split approach means:
- We need 2 functions operating in different ways instead of a single function.
- The server spends some time in a partially initialized state, which the Rust type system has to cope with.
- It violates the spirit of `initialized`. By the time `initialized` is received, everything should already be fully _initialized_. But our server isn't. It's still _initializing_.

----

This PR changes this so all the initialization is done up front, in one-shot.
The client now sends _all_ it's configuration in the first `initialize` request, so the server can fully initialize itself then.

We still receive the `initialized` request, because the server waits for it before sending diagnostics back.
Because it's unsound to send arbitrary data to the client before everyone is initialized and ready for it.

----

I remember talking about the nuance around these functions, and there's a comment that alludes that "the client might not be ready to send it's config". Reading the spec sounds like this PR is the right way to go though, and I've tested it on my machine to no issues. If anyone has any insight (or testing capabilities to offer!), I welcome it.

But currently, all our configuration just comes right out of `settings.json`, which is known and loaded by the time the extension starts. It has to be, because that's how we check if the server is enabled at all.