### PR TITLE
Tie 'include_built_in_path' and 'built_in_slice_path' together.

### DIFF
--- a/server/src/configuration_set.rs
+++ b/server/src/configuration_set.rs
@@ -16,7 +16,7 @@ impl ConfigurationSet {
     pub fn new(root_uri: Url, built_in_path: String) -> Self {
         let mut slice_config = SliceConfig::default();
         slice_config.set_root_uri(root_uri);
-        slice_config.set_built_in_path(built_in_path.to_owned());
+        slice_config.set_built_in_slice_path(Some(built_in_path));
         let compilation_state =
             slicec::compile_from_options(slice_config.as_slice_options(), |_| {}, |_| {});
         Self {
@@ -46,9 +46,8 @@ impl ConfigurationSet {
         // Create the SliceConfig and CompilationState
         let mut slice_config = SliceConfig::default();
         slice_config.set_root_uri(root_uri.clone());
-        slice_config.set_built_in_path(built_in_path.to_owned());
+        slice_config.set_built_in_slice_path(include_built_in.then(|| built_in_path.to_owned()));
         slice_config.set_search_paths(paths);
-        slice_config.update_include_built_in_path(include_built_in);
 
         let options = slice_config.as_slice_options();
         let compilation_state = slicec::compile_from_options(options, |_| {}, |_| {});

--- a/server/src/slice_config.rs
+++ b/server/src/slice_config.rs
@@ -9,8 +9,7 @@ use tower_lsp::lsp_types::Url;
 pub struct SliceConfig {
     paths: Vec<String>,
     workspace_root_path: Option<PathBuf>,
-    include_built_in_path: bool,
-    built_in_slice_path: String,
+    built_in_slice_path: Option<String>,
     cached_slice_options: SliceOptions,
 }
 
@@ -24,18 +23,13 @@ impl SliceConfig {
     }
 
     // `path` must be absolute.
-    pub fn set_built_in_path(&mut self, path: String) {
+    pub fn set_built_in_slice_path(&mut self, path: Option<String>) {
         self.built_in_slice_path = path;
         self.refresh_paths();
     }
 
     pub fn set_search_paths(&mut self, paths: Vec<String>) {
         self.paths = paths;
-        self.refresh_paths();
-    }
-
-    pub fn update_include_built_in_path(&mut self, include: bool) {
-        self.include_built_in_path = include;
         self.refresh_paths();
     }
 
@@ -63,12 +57,11 @@ impl SliceConfig {
             resolved_paths.push(root_path.display().to_string());
         }
 
-        // Add the well known types path to the end of the list.
-        // TODO: Weird case where `include_built_in_path` is true but `built_in_slice_path` is empty.
-        // We should probably handle this case better or make sure it never happens.
-        if self.include_built_in_path && !self.built_in_slice_path.is_empty() {
-            resolved_paths.push(self.built_in_slice_path.clone());
+        // Add the built-in Slice files (WellKnownTypes, etc.) to the end of the list if it's present.
+        if let Some(path) = &self.built_in_slice_path {
+            resolved_paths.push(path.clone());
         }
+
         resolved_paths
     }
 


### PR DESCRIPTION
This PR merges two of the `SliceConfig` fields into one:
```
include_built_in_path: bool,
built_in_slice_path: String,
```
become:
```
built_in_slice_path: Option<String>,
```
The bool becomes the `Option` (true = Some, false = None)
And the option holds the actual path inside itself.

This prevents the "Weird case where `include_built_in_path` is true but `built_in_slice_path` is empty."

No logic is changed by this PR. It should be strictly equivalent to the current logic.