### PR TITLE
Perform Url->Path Conversion for the Workspace Root During Initialization

### DIFF
--- a/server/src/configuration_set.rs
+++ b/server/src/configuration_set.rs
@@ -1,9 +1,9 @@
 // Copyright (c) ZeroC, Inc.
 
 use crate::slice_config;
+use std::path::{Path, PathBuf};
 use slice_config::SliceConfig;
 use slicec::compilation_state::CompilationState;
-use tower_lsp::lsp_types::Url;
 
 #[derive(Debug)]
 pub struct ConfigurationSet {
@@ -12,10 +12,10 @@ pub struct ConfigurationSet {
 }
 
 impl ConfigurationSet {
-    /// Creates a new `ConfigurationSet` using the given root URI and built-in path.
-    pub fn new(root_uri: Url, built_in_path: String) -> Self {
+    /// Creates a new `ConfigurationSet` using the given root and built-in-slice paths.
+    pub fn new(root_path: PathBuf, built_in_path: String) -> Self {
         let mut slice_config = SliceConfig::default();
-        slice_config.set_root_uri(root_uri);
+        slice_config.set_workspace_root_path(root_path);
         slice_config.set_built_in_slice_path(Some(built_in_path));
         let compilation_state =
             slicec::compile_from_options(slice_config.as_slice_options(), |_| {}, |_| {});
@@ -25,27 +25,27 @@ impl ConfigurationSet {
         }
     }
 
-    /// Parses a vector of `ConfigurationSet` from a JSON array, root URI, and built-in path.
+    /// Parses a vector of `ConfigurationSet` from a JSON array, root path, and built-in path.
     pub fn parse_configuration_sets(
         config_array: &[serde_json::Value],
-        root_uri: &Url,
+        root_path: &Path,
         built_in_path: &str,
     ) -> Vec<ConfigurationSet> {
         config_array
             .iter()
-            .map(|value| ConfigurationSet::from_json(value, root_uri, built_in_path))
+            .map(|value| ConfigurationSet::from_json(value, root_path, built_in_path))
             .collect::<Vec<_>>()
     }
 
     /// Constructs a `ConfigurationSet` from a JSON value.
-    fn from_json(value: &serde_json::Value, root_uri: &Url, built_in_path: &str) -> Self {
+    fn from_json(value: &serde_json::Value, root_path: &Path, built_in_path: &str) -> Self {
         // Parse the paths and `include_built_in_types` from the configuration set
         let paths = parse_paths(value);
         let include_built_in = parse_include_built_in(value);
 
         // Create the SliceConfig and CompilationState
         let mut slice_config = SliceConfig::default();
-        slice_config.set_root_uri(root_uri.clone());
+        slice_config.set_workspace_root_path(root_path.to_owned());
         slice_config.set_built_in_slice_path(include_built_in.then(|| built_in_path.to_owned()));
         slice_config.set_search_paths(paths);
 

--- a/server/src/session.rs
+++ b/server/src/session.rs
@@ -48,7 +48,7 @@ impl Session {
             .and_then(|uri| uri.to_file_path().ok())
             .and_then(|path| Url::from_file_path(path).ok())
             .and_then(|uri| uri.to_file_path().ok())
-            .expect("root_uri not found in initialization parameters");
+            .expect("`root_uri` was not sent by the client, or was malformed");
 
         // Load any user configuration from the 'slice.configurations' option.
         let configuration_sets = initialization_options

--- a/server/src/slice_config.rs
+++ b/server/src/slice_config.rs
@@ -2,7 +2,6 @@
 
 use std::path::{Path, PathBuf};
 use slicec::slice_options::SliceOptions;
-use tower_lsp::lsp_types::Url;
 
 // This struct holds the configuration for a single compilation set.
 #[derive(Default, Debug)]
@@ -14,12 +13,10 @@ pub struct SliceConfig {
 }
 
 impl SliceConfig {
-    // `root` must be absolute.
-    pub fn set_root_uri(&mut self, root: Url) {
-        if let Ok(root_path) = root.to_file_path() {
-            self.workspace_root_path = Some(root_path);
-            self.refresh_paths();
-        }
+    // `path` must be absolute.
+    pub fn set_workspace_root_path(&mut self, path: PathBuf) {
+        self.workspace_root_path = Some(path);
+        self.refresh_paths();
     }
 
     // `path` must be absolute.


### PR DESCRIPTION
### The only thing that actually changed

This line was added to where we initialize sessions:
`.and_then(|uri| uri.to_file_path().ok())`
This line was removed from `SliceConfig`:
`if let Ok(root_path) = root.to_file_path() {`
They do the same thing: convert a uri to a path

### Over-explaining stuff

We use `root_uri` for a single purpose: taking relative paths and making them absolute, so we can pass them to `slicec`.
But, we don't actually use a `uri` for this. We convert the `uri` to `PathBuf` before we can actually use it.

Right now, when we initialize `Session` we store a `Url`, and `SliceConfig` will convert it to `Pathbuf` when it needs it.
This PR changes this, so we perform the conversion immediately (during session initialization).

This means we only convert it once per server (instead of once for each configuration set), and if the user gives us a bogus path, we'll catch it immediately and report it, instead of 'catching' it later (`SliceConfig` actually just ignores the error).