### PR TITLE
No Longer Store Diagnostics in `CompilationState`

### DIFF
--- a/server/src/configuration_set.rs
+++ b/server/src/configuration_set.rs
@@ -29,7 +29,6 @@ unsafe impl Sync for CompilationData {}
 pub struct ConfigurationSet {
     pub slice_config: SliceConfig,
     pub compilation_data: CompilationData,
-    pub unpublished_diagnostics: Option<Vec<Diagnostic>>,
 }
 
 impl ConfigurationSet {
@@ -39,7 +38,8 @@ impl ConfigurationSet {
         slice_config.set_workspace_root_path(root_path);
         slice_config.set_built_in_slice_path(Some(built_in_path));
 
-        Self::create_and_compile(slice_config)
+        let compilation_data = CompilationData::default();
+        Self { slice_config, compilation_data }
     }
 
     /// Parses a vector of `ConfigurationSet` from a JSON array, root path, and built-in path.
@@ -66,18 +66,8 @@ impl ConfigurationSet {
         slice_config.set_built_in_slice_path(include_built_in.then(|| built_in_path.to_owned()));
         slice_config.set_search_paths(paths);
 
-        Self::create_and_compile(slice_config)
-    }
-
-    fn create_and_compile(slice_config: SliceConfig) -> Self {
-        let mut configuration_set = Self {
-            slice_config,
-            compilation_data: CompilationData::default(),
-            unpublished_diagnostics: None,
-        };
-
-        configuration_set.unpublished_diagnostics = Some(configuration_set.trigger_compilation());
-        configuration_set
+        let compilation_data = CompilationData::default();
+        Self { slice_config, compilation_data }
     }
 
     pub fn trigger_compilation(&mut self) -> Vec<Diagnostic> {

--- a/server/src/configuration_set.rs
+++ b/server/src/configuration_set.rs
@@ -22,6 +22,12 @@ impl Default for CompilationData {
     }
 }
 
+// Necessary for using `CompilationData` within async functions.
+//
+// # Safety
+//
+// These implementations are safe because `CompilationData` is entirely self-contained and hence can go between threads.
+// Note that `files` is not self-contained on its own, since `SliceFile` references definitions owned by the `Ast`.
 unsafe impl Send for CompilationData {}
 unsafe impl Sync for CompilationData {}
 

--- a/server/src/diagnostic_ext.rs
+++ b/server/src/diagnostic_ext.rs
@@ -17,15 +17,12 @@ use tower_lsp::Client;
 /// and then publishes these diagnostics to the LSP client.
 pub async fn publish_diagnostics_for_all_files(
     client: &Client,
+    diagnostics: Vec<Diagnostic>,
     configuration_set: &mut ConfigurationSet,
 ) {
     client
         .log_message(MessageType::INFO, "Publishing diagnostics...")
         .await;
-
-    // Retrieve any unpublished diagnostics from the configuration set. This function is only called after a fresh
-    // compilation, so this field should always be set. (Even if it's set to an empty vec).
-    let diagnostics = configuration_set.unpublished_diagnostics.take().expect("no diagnostics to publish");
 
     // Initialize a map to hold diagnostics grouped by file (URL)
     let mut map = configuration_set
@@ -51,14 +48,17 @@ pub async fn publish_diagnostics_for_all_files(
 ///
 /// This function iterates over all configuration sets and invokes
 /// `publish_diagnostics_for_all_files` for each set.
-pub async fn publish_diagnostics(
+pub async fn compile_and_publish_diagnostics(
     client: &Client,
     configuration_sets: &Mutex<Vec<ConfigurationSet>>,
 ) {
     let mut configuration_sets = configuration_sets.lock().await;
 
     for configuration_set in configuration_sets.iter_mut() {
-        publish_diagnostics_for_all_files(client, configuration_set).await;
+        // Trigger a compilation and get any diagnostics that were reported during it.
+        let diagnostics = configuration_set.trigger_compilation();
+        // Publish the diagnostics.
+        publish_diagnostics_for_all_files(client, diagnostics, configuration_set).await;
     }
 }
 

--- a/server/src/diagnostic_ext.rs
+++ b/server/src/diagnostic_ext.rs
@@ -44,10 +44,8 @@ pub async fn publish_diagnostics_for_all_files(
         .await;
 }
 
-/// Publishes diagnostics for all configuration sets.
-///
-/// This function iterates over all configuration sets and invokes
-/// `publish_diagnostics_for_all_files` for each set.
+/// Triggers and compilation and publishes any diagnostics that are reported.
+/// It does this for all configuration sets.
 pub async fn compile_and_publish_diagnostics(
     client: &Client,
     configuration_sets: &Mutex<Vec<ConfigurationSet>>,
@@ -57,7 +55,7 @@ pub async fn compile_and_publish_diagnostics(
     for configuration_set in configuration_sets.iter_mut() {
         // Trigger a compilation and get any diagnostics that were reported during it.
         let diagnostics = configuration_set.trigger_compilation();
-        // Publish the diagnostics.
+        // Publish those diagnostics.
         publish_diagnostics_for_all_files(client, diagnostics, configuration_set).await;
     }
 }

--- a/server/src/hover.rs
+++ b/server/src/hover.rs
@@ -1,8 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
-use crate::utils::url_to_file_path;
+use crate::{configuration_set::CompilationData, utils::url_to_file_path};
 use slicec::{
-    compilation_state::CompilationState,
     grammar::{Element, Enum, Primitive, Symbol, TypeRef, TypeRefDefinition, Types},
     slice_file::Location,
     visitor::Visitor,
@@ -10,12 +9,12 @@ use slicec::{
 use tower_lsp::lsp_types::{Hover, HoverContents, MarkedString, Position, Url};
 
 pub fn try_into_hover_result(
-    state: &CompilationState,
+    data: &CompilationData,
     uri: Url,
     position: Position,
 ) -> tower_lsp::jsonrpc::Result<Hover> {
     let file = url_to_file_path(&uri)
-        .and_then(|p| state.files.get(&p))
+        .and_then(|p| data.files.get(&p))
         .expect("Could not convert URI to Slice formatted URL for hover request");
 
     // Convert position to row and column 1 based

--- a/server/src/jump_definition.rs
+++ b/server/src/jump_definition.rs
@@ -1,8 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
-use crate::utils::url_to_file_path;
+use crate::{configuration_set::CompilationData, utils::url_to_file_path};
 use slicec::{
-    compilation_state::CompilationState,
     grammar::{
         Class, Commentable, CustomType, Entity, Enum, Enumerator, Exception, Field, Identifier,
         Interface, Message, MessageComponent, NamedSymbol, Operation, Struct, Symbol, TypeAlias,
@@ -13,11 +12,11 @@ use slicec::{
 };
 use tower_lsp::lsp_types::{Position, Url};
 
-pub fn get_definition_span(state: &CompilationState, uri: Url, position: Position) -> Option<Span> {
+pub fn get_definition_span(data: &CompilationData, uri: Url, position: Position) -> Option<Span> {
     let file_path = url_to_file_path(&uri)?;
 
-    // Attempt to retrieve the file from the state
-    let file = state.files.get(&file_path)?;
+    // Attempt to retrieve the file from the data
+    let file = data.files.get(&file_path)?;
 
     // Convert position to row and column 1 based
     let col = (position.character + 1) as usize;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -127,11 +127,11 @@ impl LanguageServer for Backend {
 
         // Find the configuration set that contains the file
         let configuration_sets = self.session.configuration_sets.lock().await;
-        let compilation_state = configuration_sets.iter().find_file(&file_name);
+        let compilation_data = configuration_sets.iter().find_file(&file_name);
 
         // Get the definition span and convert it to a GotoDefinitionResponse
-        compilation_state
-            .and_then(|state| get_definition_span(state, url, position))
+        compilation_data
+            .and_then(|data| get_definition_span(data, url, position))
             .and_then(|location| {
                 let start = Position {
                     line: (location.start.row - 1) as u32,
@@ -167,8 +167,8 @@ impl LanguageServer for Backend {
         Ok(configuration_sets
             .iter()
             .find_file(&file_name)
-            .and_then(|compilation_state| {
-                try_into_hover_result(compilation_state, url, position).ok()
+            .and_then(|compilation_data| {
+                try_into_hover_result(compilation_data, url, position).ok()
             }))
     }
 
@@ -197,28 +197,18 @@ impl Backend {
 
         // Process each configuration set that contains the changed file
         for set in configuration_sets.iter_mut().filter(|set| {
-            set.compilation_state.files.keys().any(|f| {
+            set.compilation_data.files.keys().any(|f| {
                 let key_path = Path::new(f);
                 let file_path = Path::new(file_name);
                 key_path == file_path || file_path.starts_with(key_path)
             })
         }) {
-            // Update the compilation state of the configuration set
-            let slice_options = set.slice_config.as_slice_options();
-            set.compilation_state = slicec::compile_from_options(slice_options, |_| {}, |_| {});
-
-            // Collect the diagnostics of the compilation state
-            diagnostics.extend(
-                std::mem::take(&mut set.compilation_state.diagnostics).into_updated(
-                    &set.compilation_state.ast,
-                    &set.compilation_state.files,
-                    slice_options,
-                ),
-            );
+            // `trigger_compilation` compiles the configuration set's files and returns any diagnostics.
+            diagnostics.extend(set.trigger_compilation());
 
             // Update publish_map with files to be updated
             publish_map.extend(
-                set.compilation_state
+                set.compilation_data
                     .files
                     .keys()
                     .filter_map(|uri| convert_slice_url_to_uri(uri))

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-use diagnostic_ext::{clear_diagnostics, process_diagnostics, publish_diagnostics};
+use diagnostic_ext::{clear_diagnostics, compile_and_publish_diagnostics, process_diagnostics};
 use hover::try_into_hover_result;
 use jump_definition::get_definition_span;
 use std::collections::HashMap;
@@ -87,8 +87,8 @@ impl LanguageServer for Backend {
     }
 
     async fn initialized(&self, _: InitializedParams) {
-        // Now that the server and client are fully initialized, it's safe to publish any diagnostics we've found.
-        publish_diagnostics(&self.client, &self.session.configuration_sets).await;
+        // Now that the server and client are fully initialized, it's safe to compile and publish any diagnostics.
+        compile_and_publish_diagnostics(&self.client, &self.session.configuration_sets).await;
     }
 
     async fn shutdown(&self) -> tower_lsp::jsonrpc::Result<()> {
@@ -107,8 +107,8 @@ impl LanguageServer for Backend {
         // Update the stored configuration sets from the data provided in the client notification
         self.session.update_configurations_from_params(params).await;
 
-        // Publish the diagnostics for all files
-        publish_diagnostics(&self.client, &self.session.configuration_sets).await;
+        // Trigger a compilation and publish the diagnostics for all files
+        compile_and_publish_diagnostics(&self.client, &self.session.configuration_sets).await;
     }
 
     async fn goto_definition(

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -1,28 +1,27 @@
 // Copyright (c) ZeroC, Inc.
 
-use crate::configuration_set::ConfigurationSet;
-use slicec::compilation_state::CompilationState;
+use crate::configuration_set::{CompilationData, ConfigurationSet};
 use std::path::Path;
 use tower_lsp::lsp_types::Url;
 
 // A helper trait that allows us to find a file in an iterator of ConfigurationSet.
 pub trait FindFile<'a> {
-    fn find_file(self, file_name: &str) -> Option<&'a CompilationState>;
+    fn find_file(self, file_name: &str) -> Option<&'a CompilationData>;
 }
 
 impl<'a, I> FindFile<'a> for I
 where
     I: Iterator<Item = &'a ConfigurationSet>,
 {
-    fn find_file(mut self, file_name: &str) -> Option<&'a CompilationState> {
+    fn find_file(mut self, file_name: &str) -> Option<&'a CompilationData> {
         self.find(|set| {
-            set.compilation_state.files.keys().any(|f| {
+            set.compilation_data.files.keys().any(|f| {
                 let key_path = Path::new(f);
                 let file_path = Path::new(file_name);
                 key_path == file_path || file_path.starts_with(key_path)
             })
         })
-        .map(|set| &set.compilation_state)
+        .map(|set| &set.compilation_data)
     }
 }
 


### PR DESCRIPTION
Currently, the extension directly uses `CompilationState` (ast, files, diagnostics) from `slicec`.
This PR adds a new type to replace it: `CompilationData`. This type only holds (ast, files).
It does this to simplify how we get, and publish diagnostics.

Currently:
- We compile immediately. The moment we create a new `ConfigurationSet`, it compiles.
  Usually, we aren't ready to publish diagnostics at this point, so we need to temporarily store them, just for a bit.
- `CompilationState` has a required `diagnostics` field. When we're ready to publish diagnostics, we use `mem::take` to
  take the diagnostics from the state and publish them. This means we have to be careful to _only_ call this after freshly compiling (otherwise there's nothing to take), and make sure we don't touch `diagnostics` afterwards (since it was taken).
So, it being a required field is a little strange. 99% of the time it's actually been taken out.

I also think it's a little strange that just making a `Configuration` triggers a compilation.
That's pretty heavy for a constructor, and I'd expect it to be a different function you call on it.

----

`CompilationData` solves these problems:
- You can create it, without triggering a compilation.
- It has a separate function for that: `trigger_compilation`.
- This function returns you the diagnostics.

So, now we create the `CompilationData`, then, when we're actually ready to compile and report diagnostics,
we call `trigger_compilation`. No more `mem::take`, no more hackily storing the diagnostics temporarily.

It also has the side-benefit of centralizing where we compile.
Before this PR, we call `slicec::compile_from...` in 3 places. Now it's only called from `trigger_compilation`.