### PR TITLE
Sanitize File Paths

### DIFF
--- a/server/src/configuration_set.rs
+++ b/server/src/configuration_set.rs
@@ -1,11 +1,12 @@
 // Copyright (c) ZeroC, Inc.
 
 use crate::slice_config;
+use crate::utils::sanitize_path;
 use std::path::{Path, PathBuf};
 use std::collections::HashMap;
 use slice_config::SliceConfig;
-use slicec::{ast::Ast, diagnostics::Diagnostic, slice_file::SliceFile};
 use slicec::compilation_state::CompilationState;
+use slicec::{ast::Ast, diagnostics::Diagnostic, slice_file::SliceFile};
 
 #[derive(Debug)]
 pub struct CompilationData {
@@ -100,7 +101,7 @@ fn parse_paths(value: &serde_json::Value) -> Vec<String> {
             dirs_array
                 .iter()
                 .filter_map(|v| v.as_str())
-                .map(String::from)
+                .map(sanitize_path)
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default()

--- a/server/src/configuration_set.rs
+++ b/server/src/configuration_set.rs
@@ -5,8 +5,8 @@ use crate::utils::sanitize_path;
 use std::path::{Path, PathBuf};
 use std::collections::HashMap;
 use slice_config::SliceConfig;
-use slicec::compilation_state::CompilationState;
 use slicec::{ast::Ast, diagnostics::Diagnostic, slice_file::SliceFile};
+use slicec::compilation_state::CompilationState;
 
 #[derive(Debug)]
 pub struct CompilationData {

--- a/server/src/diagnostic_ext.rs
+++ b/server/src/diagnostic_ext.rs
@@ -182,7 +182,7 @@ fn try_into_lsp_diagnostic_related_information(
     note: &Note,
 ) -> Option<tower_lsp::lsp_types::DiagnosticRelatedInformation> {
     let span = note.span.as_ref()?;
-    let file_path = Url::from_file_path(span.file.clone()).ok()?;
+    let file_path = convert_slice_url_to_uri(&span.file)?;
     let start_position = Position::new((span.start.row - 1) as u32, (span.start.col - 1) as u32);
     let end_position = Position::new((span.end.row - 1) as u32, (span.end.col - 1) as u32);
 

--- a/server/src/hover.rs
+++ b/server/src/hover.rs
@@ -1,21 +1,13 @@
 // Copyright (c) ZeroC, Inc.
 
-use crate::{configuration_set::CompilationData, utils::url_to_file_path};
 use slicec::{
     grammar::{Element, Enum, Primitive, Symbol, TypeRef, TypeRefDefinition, Types},
-    slice_file::Location,
+    slice_file::{Location, SliceFile},
     visitor::Visitor,
 };
-use tower_lsp::lsp_types::{Hover, HoverContents, MarkedString, Position, Url};
+use tower_lsp::lsp_types::{Hover, HoverContents, MarkedString, Position};
 
-pub fn try_into_hover_result(
-    data: &CompilationData,
-    uri: Url,
-    position: Position,
-) -> tower_lsp::jsonrpc::Result<Hover> {
-    let file = url_to_file_path(&uri)
-        .and_then(|p| data.files.get(&p))
-        .expect("Could not convert URI to Slice formatted URL for hover request");
+pub fn try_into_hover_result(file: &SliceFile, position: Position) -> tower_lsp::jsonrpc::Result<Hover> {
 
     // Convert position to row and column 1 based
     let col = (position.character + 1) as usize;

--- a/server/src/hover.rs
+++ b/server/src/hover.rs
@@ -7,8 +7,10 @@ use slicec::{
 };
 use tower_lsp::lsp_types::{Hover, HoverContents, MarkedString, Position};
 
-pub fn try_into_hover_result(file: &SliceFile, position: Position) -> tower_lsp::jsonrpc::Result<Hover> {
-
+pub fn try_into_hover_result(
+    file: &SliceFile,
+    position: Position,
+) -> tower_lsp::jsonrpc::Result<Hover> {
     // Convert position to row and column 1 based
     let col = (position.character + 1) as usize;
     let row = (position.line + 1) as usize;

--- a/server/src/jump_definition.rs
+++ b/server/src/jump_definition.rs
@@ -1,23 +1,17 @@
 // Copyright (c) ZeroC, Inc.
 
-use crate::{configuration_set::CompilationData, utils::url_to_file_path};
 use slicec::{
     grammar::{
         Class, Commentable, CustomType, Entity, Enum, Enumerator, Exception, Field, Identifier,
         Interface, Message, MessageComponent, NamedSymbol, Operation, Struct, Symbol, TypeAlias,
         TypeRef, TypeRefDefinition, Types,
     },
-    slice_file::{Location, Span},
+    slice_file::{Location, SliceFile, Span},
     visitor::Visitor,
 };
-use tower_lsp::lsp_types::{Position, Url};
+use tower_lsp::lsp_types::Position;
 
-pub fn get_definition_span(data: &CompilationData, uri: Url, position: Position) -> Option<Span> {
-    let file_path = url_to_file_path(&uri)?;
-
-    // Attempt to retrieve the file from the data
-    let file = data.files.get(&file_path)?;
-
+pub fn get_definition_span(file: &SliceFile, position: Position) -> Option<Span> {
     // Convert position to row and column 1 based
     let col = (position.character + 1) as usize;
     let row = (position.line + 1) as usize;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -189,7 +189,7 @@ impl LanguageServer for Backend {
         // Get the definition span and convert it to a GotoDefinitionResponse
         compilation_data
             .and_then(|data| {
-                let file = data.files.get(&file_path).expect("bad file in goto request");
+                let file = data.files.get(&file_path).expect("mismatch in file name occurred during goto request");
                 get_definition_span(file, position)
             })
             .and_then(|location| {
@@ -225,7 +225,7 @@ impl LanguageServer for Backend {
             .iter()
             .find_file(&file_path)
             .and_then(|data| {
-                let file = data.files.get(&file_path).expect("file missing for hover request");
+                let file = data.files.get(&file_path).expect("mismatch in file name occurred during hover request");
                 try_into_hover_result(file, position).ok()
             }))
     }

--- a/server/src/session.rs
+++ b/server/src/session.rs
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-use crate::configuration_set::ConfigurationSet;
+use crate::{configuration_set::ConfigurationSet, utils::sanitize_slice_path};
 use std::path::PathBuf;
 use tokio::sync::{Mutex, RwLock};
 use tower_lsp::lsp_types::{DidChangeConfigurationParams, Url};
@@ -34,11 +34,13 @@ impl Session {
 
         // This is the path to the built-in Slice files that are included with the extension. It should always
         // be present.
-        let built_in_slice_path = initialization_options
+        let mut built_in_slice_path = initialization_options
             .as_ref()
             .and_then(|opts| opts.get("builtInSlicePath"))
             .and_then(|v| v.as_str().map(str::to_owned))
             .expect("builtInSlicePath not found in initialization options");
+
+        sanitize_slice_path(&mut built_in_slice_path);
 
         // Use the root_uri if it exists temporarily as we cannot access configuration until
         // after initialization. Additionally, LSP may provide the windows path with escaping or a lowercase

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -25,6 +25,8 @@ where
     }
 }
 
+// This helper function converts a Url from tower_lsp into a string that can be used to
+// retrieve a file from the compilation state from slicec.
 pub fn url_to_sanitized_file_path(url: &Url) -> Option<String> {
     let path = url.to_file_path().ok()?;
     let path_string = path.to_str()?;
@@ -46,10 +48,10 @@ pub fn sanitize_path(s: &str) -> String {
     if let Some(Component::Prefix(prefix)) = Path::new(&sanitized_path).components().next() {
         if matches!(prefix.kind(), Prefix::Disk(_) | Prefix::VerbatimDisk(_)) {
             // disk prefixes are always of the form 'C:' or '\\?\C:'
-            let colon_index = sanitized_path.find(':').expect("no colon found in disk prefix");
+            let colon_index = sanitized_path.find(':').expect("no colon in disk prefix");
             let disk_prefix = sanitized_path.split_at_mut(colon_index).0;
 
-             // Windows disk prefixes only use ascii characters.
+            // Windows disk prefixes only use ascii characters.
             assert!(disk_prefix.is_ascii());
             disk_prefix.make_ascii_uppercase()
         }

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -1,7 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 use crate::configuration_set::{CompilationData, ConfigurationSet};
-use std::path::Path;
+use std::path::{Component, Path, Prefix};
 use tower_lsp::lsp_types::Url;
 
 // A helper trait that allows us to find a file in an iterator of ConfigurationSet.
@@ -22,6 +22,19 @@ where
             })
         })
         .map(|set| &set.compilation_data)
+    }
+}
+
+pub fn sanitize_slice_path(path_string: &mut str) {
+    // Check if the path begins with a drive prefix (windows), and if so, make sure it's capitalized.
+    if let Some(Component::Prefix(prefix)) = Path::new(path_string).components().next() {
+        if matches!(prefix.kind(), Prefix::Disk(_) | Prefix::VerbatimDisk(_)) {
+            // Drive prefixes are always of the form 'C:' or '\\?\C:'
+            let colon_index = path_string.find(':').expect("no colon found in disk prefix");
+            let disk_prefix = path_string.split_at_mut(colon_index).0;
+            assert!(disk_prefix.is_ascii()); // Windows disk prefixes only use ascii characters.
+            disk_prefix.make_ascii_uppercase()
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds a new function: `sanitize_path`.

There are two implementations of the function, which are selected based on the target-os we're compiling for.
The Unix/Mac version does nothing. The Windows version:
- replaces forward slashes with bask-slashes
- if there's a disk prefix, we ensure it's capitalized

All of the places where we receive a path from the client use this function now, instead of half-sanitizing them using chains of 'to_file_path', 'from_file_path', etc.

----

The actual function is at the end of this PR. If you could really give it a proper look it'd be appreciated.
Doing string manipulation based on character indexes is always prone for fun bugs : vP