### PR TITLE
Centralize server-level config in new 'ServerConfig' struct.

### DIFF
--- a/server/src/session.rs
+++ b/server/src/session.rs
@@ -1,39 +1,39 @@
 // Copyright (c) ZeroC, Inc.
 
-use crate::{
-    configuration_set::ConfigurationSet,
-    utils::{sanitize_path, url_to_sanitized_file_path},
-};
+use crate::configuration_set::ConfigurationSet;
+use crate::slice_config::ServerConfig;
+use crate::utils::{sanitize_path, url_to_sanitized_file_path};
 use std::path::PathBuf;
 use tokio::sync::{Mutex, RwLock};
 use tower_lsp::lsp_types::DidChangeConfigurationParams;
 
+#[derive(Debug, Default)]
 pub struct Session {
     /// This vector contains all of the configuration sets for the language server. Each element is a tuple containing
     /// `SliceConfig` and `CompilationState`. The `SliceConfig` is used to determine which configuration set to use when
     /// publishing diagnostics. The `CompilationState` is used to retrieve the diagnostics for a given file.
     pub configuration_sets: Mutex<Vec<ConfigurationSet>>,
-    /// This is the root path of the workspace. It is used to resolve relative paths in the configuration.
-    pub root_path: RwLock<Option<PathBuf>>,
-    /// This is the path to the built-in Slice files that are included with the extension.
-    pub built_in_slice_path: RwLock<String>,
+    /// Configuration that affects the entire server.
+    pub server_config: RwLock<ServerConfig>,
 }
 
 impl Session {
-    pub fn new() -> Self {
-        Self {
-            configuration_sets: Mutex::new(Vec::new()),
-            root_path: RwLock::new(None),
-            built_in_slice_path: RwLock::new(String::new()),
-        }
-    }
-
     // Update the properties of the session from `InitializeParams`
     pub async fn update_from_initialize_params(
         &self,
         params: tower_lsp::lsp_types::InitializeParams,
     ) {
         let initialization_options = params.initialization_options;
+
+        // Use the root_uri if it exists temporarily as we cannot access configuration until
+        // after initialization. Additionally, LSP may provide the windows path with escaping or a lowercase
+        // drive letter. To fix this, we convert the path to a URL and then back to a path.
+        let workspace_root_path = params
+            .root_uri
+            .and_then(|uri| url_to_sanitized_file_path(&uri))
+            .map(PathBuf::from)
+            .map(|path| path.display().to_string())
+            .expect("`root_uri` was not sent by the client, or was malformed");
 
         // This is the path to the built-in Slice files that are included with the extension. It should always
         // be present.
@@ -44,43 +44,28 @@ impl Session {
             .map(sanitize_path)
             .expect("builtInSlicePath not found in initialization options");
 
-        // Use the root_uri if it exists temporarily as we cannot access configuration until
-        // after initialization. Additionally, LSP may provide the windows path with escaping or a lowercase
-        // drive letter. To fix this, we convert the path to a URL and then back to a path.
-        let root_path = params
-            .root_uri
-            .and_then(|uri| url_to_sanitized_file_path(&uri))
-            .map(PathBuf::from)
-            .expect("`root_uri` was not sent by the client, or was malformed");
+        *self.server_config.write().await = ServerConfig { workspace_root_path, built_in_slice_path };
 
         // Load any user configuration from the 'slice.configurations' option.
         let configuration_sets = initialization_options
             .as_ref()
             .and_then(|opts| opts.get("configurations"))
             .and_then(|v| v.as_array())
-            .map(|arr| {
-                ConfigurationSet::parse_configuration_sets(arr, &root_path, &built_in_slice_path)
-            })
+            .map(|arr| ConfigurationSet::parse_configuration_sets(arr))
             .unwrap_or_default();
 
-        *self.built_in_slice_path.write().await = built_in_slice_path;
-        *self.root_path.write().await = Some(root_path);
         self.update_configurations(configuration_sets).await;
     }
 
     // Update the configuration sets from the `DidChangeConfigurationParams` notification.
     pub async fn update_configurations_from_params(&self, params: DidChangeConfigurationParams) {
-        let built_in_path = &self.built_in_slice_path.read().await;
-        let root_path_guard = self.root_path.read().await;
-        let root_path = (*root_path_guard).clone().expect("root_path not set");
-
         // Parse the configurations from the notification
         let configurations = params
             .settings
             .get("slice")
             .and_then(|v| v.get("configurations"))
             .and_then(|v| v.as_array())
-            .map(|arr| ConfigurationSet::parse_configuration_sets(arr, &root_path, built_in_path))
+            .map(|arr| ConfigurationSet::parse_configuration_sets(arr))
             .unwrap_or_default();
 
         // Update the configuration sets
@@ -92,14 +77,9 @@ impl Session {
     async fn update_configurations(&self, mut configurations: Vec<ConfigurationSet>) {
         // Insert the default configuration set if needed
         if configurations.is_empty() {
-            let root_path = self.root_path.read().await;
-            let built_in_slice_path = self.built_in_slice_path.read().await;
-            let default =
-                ConfigurationSet::new(root_path.clone().unwrap(), built_in_slice_path.clone());
-            configurations.push(default);
+            configurations.push(ConfigurationSet::default());
         }
 
-        let mut configuration_sets = self.configuration_sets.lock().await;
-        *configuration_sets = configurations;
+        *self.configuration_sets.lock().await = configurations;
     }
 }

--- a/server/src/slice_config.rs
+++ b/server/src/slice_config.rs
@@ -1,45 +1,62 @@
 // Copyright (c) ZeroC, Inc.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
-// This struct holds the configuration for a single compilation set.
-#[derive(Debug)]
-pub struct SliceConfig {
-    pub paths: Vec<String>,
-    pub workspace_root_path: Option<PathBuf>,
-    pub built_in_slice_path: Option<String>,
+use slicec::slice_options::SliceOptions;
+
+/// This struct holds configuration that affects the entire server.
+#[derive(Debug, Default)]
+pub struct ServerConfig {
+    /// This is the root path of the workspace, used to resolve relative paths. It must be an absolute path.
+    pub workspace_root_path: String,
+    /// This is the path to the built-in Slice files that are included with the extension. It must be an absolute path.
+    pub built_in_slice_path: String,
 }
 
-impl SliceConfig {
-    // Resolve path URIs to file paths to be used by the Slice compiler.
-    pub fn resolve_paths(&self) -> Vec<String> {
-        // If `root_path` isn't set, relative path resolution is impossible, so we return.
-        let Some(root_path) = &self.workspace_root_path else {
-            return vec![];
-        };
+/// This struct holds the configuration for a single compilation set.
+#[derive(Debug)]
+pub struct SliceConfig {
+    /// List of paths that will be passed to the compiler as reference files/directories.
+    pub slice_search_paths: Vec<String>,
+    /// Specifies whether to include the built-in Slice files that are bundled with the extension.
+    pub include_built_in_slice_files: bool,
+}
 
-        let mut resolved_paths = Vec::new();
-        for string_path in &self.paths {
-            let path = Path::new(string_path);
-
-            // If the path is absolute, add it as-is. Otherwise, preface it with the workspace root.
-            let absolute_path = match path.is_absolute() {
-                true => path.to_owned(),
-                false => root_path.join(path),
-            };
-            resolved_paths.push(absolute_path.display().to_string());
+impl Default for SliceConfig {
+    fn default() -> Self {
+        SliceConfig {
+            slice_search_paths: vec![],
+            include_built_in_slice_files: true,
         }
-
-        // If the user didn't specify any paths, default to using the workspace root.
-        if resolved_paths.is_empty() {
-            resolved_paths.push(root_path.display().to_string());
-        }
-
-        // Add the built-in Slice files (WellKnownTypes, etc.) to the end of the list if it's present.
-        if let Some(path) = &self.built_in_slice_path {
-            resolved_paths.push(path.clone());
-        }
-
-        resolved_paths
     }
+}
+
+pub fn compute_slice_options(server_config: &ServerConfig, unit_config: &SliceConfig) -> SliceOptions {
+    let root_path = Path::new(&server_config.workspace_root_path);
+    let mut slice_options = SliceOptions::default();
+    let references = &mut slice_options.references;
+
+    // Add any user specified search paths at the front of the list.
+    for string_path in &unit_config.slice_search_paths {
+        let path = Path::new(string_path);
+
+        // If the path is absolute, add it as-is. Otherwise, preface it with the workspace root.
+        let absolute_path = match path.is_absolute() {
+            true => path.to_owned(),
+            false => root_path.join(path),
+        };
+        references.push(absolute_path.display().to_string());
+    }
+
+    // If the user didn't specify any paths, default to using the workspace root.
+    if references.is_empty() {
+        references.push(root_path.display().to_string());
+    }
+
+    // Add the built-in Slice files (WellKnownTypes, etc.) to the end of the list, if they should be included.
+    if unit_config.include_built_in_slice_files {
+        references.push(server_config.built_in_slice_path.clone());
+    }
+
+    slice_options
 }

--- a/server/src/slice_config.rs
+++ b/server/src/slice_config.rs
@@ -31,13 +31,13 @@ impl Default for SliceConfig {
     }
 }
 
-pub fn compute_slice_options(server_config: &ServerConfig, unit_config: &SliceConfig) -> SliceOptions {
+pub fn compute_slice_options(server_config: &ServerConfig, set_config: &SliceConfig) -> SliceOptions {
     let root_path = Path::new(&server_config.workspace_root_path);
     let mut slice_options = SliceOptions::default();
     let references = &mut slice_options.references;
 
     // Add any user specified search paths at the front of the list.
-    for string_path in &unit_config.slice_search_paths {
+    for string_path in &set_config.slice_search_paths {
         let path = Path::new(string_path);
 
         // If the path is absolute, add it as-is. Otherwise, preface it with the workspace root.
@@ -54,7 +54,7 @@ pub fn compute_slice_options(server_config: &ServerConfig, unit_config: &SliceCo
     }
 
     // Add the built-in Slice files (WellKnownTypes, etc.) to the end of the list, if they should be included.
-    if unit_config.include_built_in_slice_files {
+    if set_config.include_built_in_slice_files {
         references.push(server_config.built_in_slice_path.clone());
     }
 


### PR DESCRIPTION
Currently, we store server-level configuration (the workspace_root and the built_in_slice_paths) in 2 places:
Once (the main one) in `Session`, but we also store copies of this data in every instance of `SliceConfig` too.

This PR removes the copies from `SliceConfig`. Now they're only stored in a single location (`Session`).
It also introduces a new `ServerConfig` to hold these data-points, so it's easier to pass around (instead of 2 separate fields).

Any time we need access to the server configuration, instead of using the copy in `SliceConfig`, we just take a `&ServerConfig` that the caller passes in.

----

This change means that we no longer need to fetch the root paths when constructing a `SliceConfig`.
This actually ends up simplifying alot of code, and lets us introduce `Default` implementations for a few types too.