### PR TITLE
Use Paths Everywhere

### DIFF
--- a/server/src/configuration_set.rs
+++ b/server/src/configuration_set.rs
@@ -3,6 +3,7 @@
 use crate::slice_config::{compute_slice_options, ServerConfig, SliceConfig};
 use crate::utils::sanitize_path;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use slicec::slice_options::SliceOptions;
 use slicec::{ast::Ast, diagnostics::Diagnostic, slice_file::SliceFile};
 use slicec::compilation_state::CompilationState;
@@ -10,7 +11,7 @@ use slicec::compilation_state::CompilationState;
 #[derive(Debug, Default)]
 pub struct CompilationData {
     pub ast: Ast,
-    pub files: HashMap<String, SliceFile>,
+    pub files: HashMap<PathBuf, SliceFile>,
 }
 
 // Necessary for using `CompilationData` within async functions.
@@ -60,6 +61,9 @@ impl ConfigurationSet {
 
         // Process the diagnostics (filter out allowed lints, and update diagnostic levels as necessary).
         let updated_diagnostics = diagnostics.into_updated(&ast, &files, slice_options);
+
+        // Convert the stringified paths returned by `slicec` to actual PathBuf objects.
+        let files = files.into_iter().map(|(k, v)| (PathBuf::from(k), v)).collect();
 
         // Store the data we got from compiling, then return the diagnostics so they can be published.
         self.compilation_data = CompilationData { ast, files };

--- a/server/src/configuration_set.rs
+++ b/server/src/configuration_set.rs
@@ -72,7 +72,7 @@ impl ConfigurationSet {
 }
 
 /// Parses paths from a JSON value.
-fn parse_paths(value: &serde_json::Value) -> Vec<String> {
+fn parse_paths(value: &serde_json::Value) -> Vec<PathBuf> {
     value
         .get("paths")
         .and_then(|v| v.as_array())
@@ -80,7 +80,7 @@ fn parse_paths(value: &serde_json::Value) -> Vec<String> {
             dirs_array
                 .iter()
                 .filter_map(|v| v.as_str())
-                .map(sanitize_path)
+                .map(|s| PathBuf::from(sanitize_path(s)))
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default()

--- a/server/src/diagnostic_ext.rs
+++ b/server/src/diagnostic_ext.rs
@@ -2,7 +2,7 @@
 
 use crate::configuration_set::ConfigurationSet;
 use crate::session::Session;
-use crate::utils::convert_slice_url_to_uri;
+use crate::utils::convert_slice_path_to_uri;
 use crate::{notifications, show_popup};
 
 use slicec::diagnostics::{Diagnostic, DiagnosticLevel, Note};
@@ -27,7 +27,7 @@ pub async fn publish_diagnostics_for_set(
         .compilation_data
         .files
         .keys()
-        .filter_map(|uri| Some((convert_slice_url_to_uri(uri)?, vec![])))
+        .filter_map(|uri| Some((convert_slice_path_to_uri(uri)?, vec![])))
         .collect::<HashMap<Url, Vec<tower_lsp::lsp_types::Diagnostic>>>();
 
     // Process the diagnostics and populate the map.
@@ -87,7 +87,7 @@ pub fn process_diagnostics(
                     let file = span
                         .expect("If the span was empty, try_into_lsp_diagnostic should have hit the error case")
                         .file;
-                    let uri = convert_slice_url_to_uri(&file)?;
+                    let uri = convert_slice_path_to_uri(file)?;
                     Some((uri, lsp_diagnostic))
                 }
                 Err(diagnostic) => {
@@ -114,8 +114,7 @@ pub async fn clear_diagnostics(client: &Client, configuration_sets: &Mutex<Vec<C
             .compilation_data
             .files
             .keys()
-            .cloned()
-            .filter_map(|uri| convert_slice_url_to_uri(&uri))
+            .filter_map(convert_slice_path_to_uri)
             .for_each(|uri| {
                 all_tracked_files.insert(uri);
             });
@@ -181,7 +180,7 @@ fn try_into_lsp_diagnostic_related_information(
     note: &Note,
 ) -> Option<tower_lsp::lsp_types::DiagnosticRelatedInformation> {
     let span = note.span.as_ref()?;
-    let file_path = convert_slice_url_to_uri(&span.file)?;
+    let file_path = convert_slice_path_to_uri(&span.file)?;
     let start_position = Position::new((span.start.row - 1) as u32, (span.start.col - 1) as u32);
     let end_position = Position::new((span.end.row - 1) as u32, (span.end.col - 1) as u32);
 

--- a/server/src/session.rs
+++ b/server/src/session.rs
@@ -3,7 +3,6 @@
 use crate::configuration_set::ConfigurationSet;
 use crate::slice_config::ServerConfig;
 use crate::utils::{sanitize_path, url_to_sanitized_file_path};
-use std::path::PathBuf;
 use tokio::sync::{Mutex, RwLock};
 use tower_lsp::lsp_types::DidChangeConfigurationParams;
 
@@ -31,7 +30,6 @@ impl Session {
         let workspace_root_path = params
             .root_uri
             .and_then(|uri| url_to_sanitized_file_path(&uri))
-            .map(PathBuf::from)
             .map(|path| path.display().to_string())
             .expect("`root_uri` was not sent by the client, or was malformed");
 

--- a/server/src/session.rs
+++ b/server/src/session.rs
@@ -30,7 +30,6 @@ impl Session {
         let workspace_root_path = params
             .root_uri
             .and_then(|uri| url_to_sanitized_file_path(&uri))
-            .map(|path| path.display().to_string())
             .expect("`root_uri` was not sent by the client, or was malformed");
 
         // This is the path to the built-in Slice files that are included with the extension. It should always

--- a/server/src/slice_config.rs
+++ b/server/src/slice_config.rs
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-use std::path::Path;
+use std::path::PathBuf;
 
 use slicec::slice_options::SliceOptions;
 
@@ -8,7 +8,7 @@ use slicec::slice_options::SliceOptions;
 #[derive(Debug, Default)]
 pub struct ServerConfig {
     /// This is the root path of the workspace, used to resolve relative paths. It must be an absolute path.
-    pub workspace_root_path: String,
+    pub workspace_root_path: PathBuf,
     /// This is the path to the built-in Slice files that are included with the extension. It must be an absolute path.
     pub built_in_slice_path: String,
 }
@@ -17,7 +17,7 @@ pub struct ServerConfig {
 #[derive(Debug)]
 pub struct SliceConfig {
     /// List of paths that will be passed to the compiler as reference files/directories.
-    pub slice_search_paths: Vec<String>,
+    pub slice_search_paths: Vec<PathBuf>,
     /// Specifies whether to include the built-in Slice files that are bundled with the extension.
     pub include_built_in_slice_files: bool,
 }
@@ -32,14 +32,12 @@ impl Default for SliceConfig {
 }
 
 pub fn compute_slice_options(server_config: &ServerConfig, set_config: &SliceConfig) -> SliceOptions {
-    let root_path = Path::new(&server_config.workspace_root_path);
+    let root_path = &server_config.workspace_root_path;
     let mut slice_options = SliceOptions::default();
     let references = &mut slice_options.references;
 
     // Add any user specified search paths at the front of the list.
-    for string_path in &set_config.slice_search_paths {
-        let path = Path::new(string_path);
-
+    for path in &set_config.slice_search_paths {
         // If the path is absolute, add it as-is. Otherwise, preface it with the workspace root.
         let absolute_path = match path.is_absolute() {
             true => path.to_owned(),


### PR DESCRIPTION
Currently, the extension deals with file addressing in two ways:
- it uses `Uri`s when communicating with the client
- it uses `String`s internally and when communicating with `slicec`.

This PR changes this so that the extension uses actual `Path` and `PathBuf` objects. (Path is to PathBuf as str is to String)

This change fixes #46, because right now, when we're searching for files, we're using string comparison.
With this change we'll use path comparisons, which account for things like `./hello` == `hello` and `mystuff\foo` == `mystuff/foo`, which obviously string comparison didn't handle.

> The real problem is we were using a mix! `find_file` did path comparison, but `files.get(..)` did string comparison.
Now we _only_ use path comparisons.

Of course, this change also lets us simplify some function changes, and makes `find_file` unnecessary
(most of it was first converting strings to paths, but now we just already have paths)