### PR TITLE
Centralize Mutex Locking

### DIFF
--- a/server/src/diagnostic_ext.rs
+++ b/server/src/diagnostic_ext.rs
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
 use crate::configuration_set::ConfigurationSet;
-use crate::session::Session;
 use crate::utils::convert_slice_path_to_uri;
 use crate::{notifications, show_popup};
 
@@ -9,7 +8,7 @@ use slicec::diagnostics::{Diagnostic, DiagnosticLevel, Note};
 use std::collections::{HashMap, HashSet};
 use tokio::sync::Mutex;
 use tower_lsp::lsp_types::{
-    DiagnosticRelatedInformation, Location, MessageType, NumberOrString, Position, Range, Url,
+    DiagnosticRelatedInformation, Location, NumberOrString, Position, Range, Url,
 };
 use tower_lsp::Client;
 
@@ -44,26 +43,6 @@ pub async fn publish_diagnostics_for_set(
     // Publish the diagnostics for each file
     for (uri, lsp_diagnostics) in map {
         client.publish_diagnostics(uri, lsp_diagnostics, None).await;
-    }
-}
-
-/// Triggers and compilation and publishes any diagnostics that are reported.
-/// It does this for all configuration sets.
-pub async fn compile_and_publish_diagnostics(client: &Client, session: &Session) {
-    let mut configuration_sets = session.configuration_sets.lock().await;
-    let server_config = session.server_config.read().await;
-
-    client
-        .log_message(
-            MessageType::INFO,
-            "Publishing diagnostics for all configuration sets.",
-        )
-        .await;
-    for configuration_set in configuration_sets.iter_mut() {
-        // Trigger a compilation and get any diagnostics that were reported during it.
-        let diagnostics = configuration_set.trigger_compilation(&server_config);
-        // Publish those diagnostics.
-        publish_diagnostics_for_set(client, diagnostics, configuration_set).await;
     }
 }
 

--- a/server/src/diagnostic_ext.rs
+++ b/server/src/diagnostic_ext.rs
@@ -6,7 +6,6 @@ use crate::{notifications, show_popup};
 
 use slicec::diagnostics::{Diagnostic, DiagnosticLevel, Note};
 use std::collections::{HashMap, HashSet};
-use tokio::sync::Mutex;
 use tower_lsp::lsp_types::{
     DiagnosticRelatedInformation, Location, NumberOrString, Position, Range, Url,
 };
@@ -85,8 +84,7 @@ pub fn process_diagnostics(
 ///
 /// This function iterates over all configuration sets, collects all tracked file URIs,
 /// and then publishes empty diagnostics to clear existing ones for each URI.
-pub async fn clear_diagnostics(client: &Client, configuration_sets: &Mutex<Vec<ConfigurationSet>>) {
-    let configuration_sets = configuration_sets.lock().await;
+pub async fn clear_diagnostics(client: &Client, configuration_sets: &[ConfigurationSet]) {
     let mut all_tracked_files = HashSet::new();
     for configuration_set in configuration_sets.iter() {
         configuration_set


### PR DESCRIPTION
This PR centralizes all our locking to a single file: `main.rs`.
Every other file operates without concern or knowledge of mutexes and locks.
This makes it easier to see where and reason about how we lock things.

It also simplifies the lockes themselves. Currently, `Session` looks like:
```
pub struct Session {
    pub configuration_sets: Mutex<Vec<ConfigurationSet>>,
    pub server_config: RwLock<ServerConfig>,
}
```

Instead of having separate locks on each field, this PR moves the lock up a level to `Session` itself.
In practice, this makes no difference. *Everywhere* where we locked `server_config`, we locked `configuration_sets` on the line above it.
So, no difference to flow or performance.

And theoritically, it would be strange for 1 thread to be mutating `server_config`, while another mutates `configuration_sets`.
The configuration sets depend on the server's configuration after all. So I think requiring a thread to lock both is saner too.