### PR TITLE
Make the Packaging Script Cross-Platform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "esbuild": "^0.19.11",
         "eslint": "^8.56.0",
         "mocha": "^10.2.0",
+        "run-script-os": "^1.1.6",
         "typescript": "^5.3.3"
       },
       "engines": {
@@ -2182,6 +2183,16 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/run-script-os": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/run-script-os/-/run-script-os-1.1.6.tgz",
+      "integrity": "sha512-ql6P2LzhBTTDfzKts+Qo4H94VUKpxKDFz6QxxwaUZN0mwvi7L3lpOI7BqPCq7lgDh3XLl0dpeXwfcVIitlrYrw==",
+      "dev": true,
+      "bin": {
+        "run-os": "index.js",
+        "run-script-os": "index.js"
       }
     },
     "node_modules/safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -113,7 +113,9 @@
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
     "esbuild": "npm run esbuild-base -- --sourcemap",
     "lint": "eslint ./client/src --ext .ts,.tsx",
-    "make-readonly": "echo \"Making /slice readonly for distribution\" && chmod -R a-w ./slice",
+    "make-readonly": "echo \"Making /slice readonly for distribution\" && run-script-os",
+    "make-readonly:nix": "chmod -R a-w ./slice",
+    "make-readonly:win32": "attrib +r /s /d /l .\\slice\\*",
     "postinstall": "cd client && npm install",
     "test-compile": "tsc -p ./",
     "vscode:prepublish": "npm run make-readonly && npm run esbuild-base -- --minify",
@@ -127,6 +129,7 @@
     "esbuild": "^0.19.11",
     "eslint": "^8.56.0",
     "mocha": "^10.2.0",
+    "run-script-os": "^1.1.6",
     "typescript": "^5.3.3"
   }
 }


### PR DESCRIPTION
Some time ago I opened #32, because the scripts and actions didn't work on Windows.
This PR updates the scripts to be cross-platform... which really only requires one change.

Part of the process is making the 'slice' directory read-only, and the script did this with `chmod`.
This command doesn't exist on Windows.

So, like any good javascript developer, I added a dependency which allows our build scripts to run OS-dependent paths.
For *nix platforms, the code is the same, but now for Windows, we use the 'equivalent' command: `attrib`.