### PR TITLE
Fix Highlighting of Metadata in Generic Type Arguments

### DIFF
--- a/syntaxes/ice.tmLanguage.json
+++ b/syntaxes/ice.tmLanguage.json
@@ -713,6 +713,7 @@
                             },
                             "patterns": [
                                 {"include": "#standard"},
+                                {"include": "#storage.modifier"},
                                 {
                                     "begin": "(\\\\?[:\\w]+)|(?=\\>)",
                                     "end": "(?=;|})",
@@ -779,6 +780,7 @@
                             },
                             "patterns": [
                                 {"include": "#standard"},
+                                {"include": "#storage.modifier"},
                                 {
                                     "begin": "(\\\\?[:\\w]+)|(?=\\>)",
                                     "end": "(?=;|})",
@@ -801,6 +803,7 @@
                                             },
                                             "patterns": [
                                                 {"include": "#standard"},
+                                                {"include": "#storage.modifier"},
                                                 {
                                                     "begin": "(\\\\?[:\\w]+)|(?=\\>)",
                                                     "end": "(?=;|})",


### PR DESCRIPTION
This PR fixes a bug in the `.ice`-syntax highlighter where metadata isn't highlighting on types in generic contexts.
The bug is just that we don't include the grammar rule for metadata in this place.

I discovered this in the `Ice/operations` test during the course of https://github.com/zeroc-ice/ice/pull/2023
Before this PR:
<img width="653" alt="Screen Shot 2024-04-08 at 9 10 37 AM" src="https://github.com/zeroc-ice/vscode-slice/assets/25963603/758c909b-0a16-4bce-bd57-c7de18a28766">
After this PR:
<img width="655" alt="Screen Shot 2024-04-08 at 9 12 43 AM" src="https://github.com/zeroc-ice/vscode-slice/assets/25963603/8c5efc01-eb1b-410e-ac58-258a8eb177fe">

And here is what it currently looks like on GitHub:
https://github.com/zeroc-ice/ice/blob/59392d7b35720e42a07951beeada22e3a60cfa29/cpp/test/Ice/operations/Test.ice#L41