### PR TITLE
Place 'built-in' Slice files at the front of the 'references' list.

### DIFF
--- a/server/src/slice_config.rs
+++ b/server/src/slice_config.rs
@@ -37,7 +37,7 @@ pub fn compute_slice_options(server_config: &ServerConfig, set_config: &SliceCon
     let references = &mut slice_options.references;
 
     // Add the built-in Slice files (WellKnownTypes, etc.) at the start of the list, if they should be included.
-    // Putting them first ensures that any redefinition conflicts will appear in the users's files, and not these.
+    // Putting them first ensures that any redefinition conflicts will appear in the user's files, and not these.
     // (Since `slicec` parses files in the order that they are provided).
     if set_config.include_built_in_slice_files {
         references.push(server_config.built_in_slice_path.clone());


### PR DESCRIPTION
Now that `slicec` parses files in the order you provide them (see https://github.com/icerpc/slicec/pull/694)... this PR fixes #49.

Previously, `slicec` parsed files in a non-deterministic order, making it impossible to control which files get parsed first.
Now that this is no longer the case, this PR changes our logic so that we always parse the built-in-Slice-files _first_.

This way, if a user does have a conflict with these Slice definitions, the redefinition error will appear in their files.
(`slicec` will first parse the built-in-files, and unless we _really_ screwed up, there will be no redefinitions in them)