### PR TITLE
Improve README and Other Markdown Files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ To contribute code or documentation to this project, please follow these steps:
 
 We carefully review all contributions before accepting them, and these reviews may take
 some time. Please keep in mind there is no guarantee your contribution will be
-accepted: we may reject a pull request for any reason.
+accepted: we may reject a pull request for any reason, or no reason.
 
 ## Contact
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Slice Extension for Visual Studio Code
 
-Thank you for your interest in contributing to Slice Extension for Visual Studio Code!
+Thank you for your interest in contributing to the Slice Extension for Visual Studio Code!
 
 ## How to Contribute
 
@@ -22,9 +22,9 @@ To contribute code or documentation to this project, please follow these steps:
 
 5. Submit a pull request.
 
-We review carefully any contribution that we accept, and these reviews may take
+We carefully review all contributions before accepting them, and these reviews may take
 some time. Please keep in mind there is no guarantee your contribution will be
-accepted: we may reject a pull request for any reason, or no reason.
+accepted: we may reject a pull request for any reason.
 
 ## Contact
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ To contribute code or documentation to this project, please follow these steps:
 
 5. Submit a pull request.
 
-We carefully review all contributions before accepting them, and these reviews may take
+We carefully review all contributions that are proposed, and these reviews may take
 some time. Please keep in mind there is no guarantee your contribution will be
 accepted: we may reject a pull request for any reason, or no reason.
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -16,7 +16,7 @@ ext install "Slice"
 To build and package the extension, you must have [`vsce`](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#vsce) installed:
 
 ```shell
-npm install -g @vscode/vsce
+npm install @vscode/vsce
 ```
 
 Additionally, you need to install the extension's dependencies:
@@ -30,7 +30,7 @@ npm install
 To build and package the extension, run:
 
 ```shell
-vsce package
+npx @vscode/vsce package
 ```
 
 This generates a `.vsix` package file in the root directory of the project.

--- a/README.md
+++ b/README.md
@@ -1,38 +1,64 @@
 # Slice for Visual Studio Code
 
-This language extension adds support for highlighting Slice files within Visual Studio Code.
-It supports highlighting the following file types:
+This extension provides support for the Slice Interface Definition Language.
+
+## Features
+
+- Syntax highlighting
+- Syntax validation
+- Error detection & reporting
+- 'Go to Definition' jumping
+
+### Syntax Highlighting and Validation
+
+This extension supports syntax highlighting and validation for the following Slice file types:
 
 - `.ice` files, which use the [original Slice](https://doc.zeroc.com/ice/latest/the-slice-language) syntax
 - `.slice` files, which use the [latest Slice](https://docs.icerpc.dev/slice2) syntax
 
-Additionally, this extension provides a Slice Language Server, for `.slice` files only.
+### Error Detection and Reporting
+
+Error checking is triggered every time a Slice file is saved or opened,
+and is only available for `.slice` files.
 
 ## Configuration
 
-The Slice Language Server can be configured using the following settings:
+The Slice language server that ships with this extension can be configured with the following settings:
 
-- `slice.languageServer.enabled`: A boolean indicating whether the Slice Language Server should be enabled. Defaults
-  to `true`.
-- `slice.configurations`: An array of configuration sets. Configuration sets are independently compiled, allowing each
-  to define its own files and options for compilation.
-  - **Each configuration set is an object with the following properties:**
-  - `paths`: An array containing the paths to the target Slice reference files. Also supports directory paths.
-  - `addWellKnownTypes`: A boolean indicating whether to include the
-    [IceRpc well-known Slice files](https://github.com/icerpc/icerpc-slice/tree/main/WellKnownTypes) during compilation.
+- `slice.languageServer.enabled`: A boolean indicating whether the server should be enabled. Defaults to `true`.
+
+- `slice.configurations`: An array of configuration sets (independent groups of Slice files). This allows multiple Slice projects to exist within a single repository. Each configuration set supports the following settings:
+
+    - `paths`: An array of paths to specify which Slice files should be included in this set.
+    This field is required.
+
+    - `addWellKnownTypes`: A boolean indicating whether to include the Slice definitions contained in the [IceRPC Slice](https://github.com/icerpc/icerpc-slice) repository.
+    These types are commonly used in applications utilizing Slice.
+    Defaults to `true`.
+
+If you do not specify any configuration sets, the extension will default to using the project's root directory for `paths`.
+
+**Note:** the language server only works with `.slice` files, and will ignore any `.ice` files in your project. The above settings are only meaningful for projects using `.slice` files.
 
 ### Example
 
+Below is an example `settings.json` file which configures 2 separate Slice projects:
+
 ```json
 {
+    "slice.languageServer.enabled": true,
     "slice.configurations": [
         {
             "paths": [
-                "path/to/slice/directory",
-                "path/to/other/slice/file.slice",
-                "/absolute/path/to/directory"  
-            ],
-            "addWellKnownTypes": true
+                "path/to/slice/directory"
+            ]
+        },
+        {
+            "addWellKnownTypes": false,
+            "paths": [
+                "path/to/specific/file.slice",
+                "/absolute/path/to/other/slice/files",
+            ]
         }
     ]
 }


### PR DESCRIPTION
This PR updates the wording of our main README, in accordance with #45,
and tweaks some minor wording/commands in our other markdown files.

The only point that I didn't address in #45 was mentioning the location of the `settings.json` file.
This went unaddressed because it can have multiple locations. There are per-user, per-workspace, and even per-folder variants of this file, so there's no simple way to tell the user where to find it.

A cursory google search should point them in the right direction though, so I'm not too worried about it.