### PR TITLE
Add Functions for Converting Between 'slicec' and 'tower_lsp' Types

### DIFF
--- a/server/src/jump_definition.rs
+++ b/server/src/jump_definition.rs
@@ -1,5 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
+use crate::utils::position_to_location;
 use slicec::{
     grammar::{
         Class, Commentable, CustomType, Entity, Enum, Enumerator, Exception, Field, Identifier,
@@ -12,11 +13,7 @@ use slicec::{
 use tower_lsp::lsp_types::Position;
 
 pub fn get_definition_span(file: &SliceFile, position: Position) -> Option<Span> {
-    // Convert position to row and column 1 based
-    let col = (position.character + 1) as usize;
-    let row = (position.line + 1) as usize;
-
-    let mut visitor = JumpVisitor::new(Location { row, col });
+    let mut visitor = JumpVisitor::new(position_to_location(position));
     file.visit_with(&mut visitor);
 
     visitor.found_span

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -1,7 +1,9 @@
 // Copyright (c) ZeroC, Inc.
 
 use std::path::{Path, PathBuf};
-use tower_lsp::lsp_types::Url;
+
+use slicec::slice_file::{Location, Span};
+use tower_lsp::lsp_types::{Position, Range, Url};
 
 // This helper function converts a Url from tower_lsp into a path that can be used to
 // retrieve a file from the compilation state from slicec.
@@ -41,4 +43,24 @@ pub fn sanitize_path(s: &str) -> String {
 #[cfg(not(target_os = "windows"))]
 pub fn sanitize_path(s: &str) -> String {
     s.to_owned()
+}
+
+/// Converts a [`slicec::slice_file::Span`] into a [`tower_lsp::lsp_types::Range`].
+pub fn span_to_range(span: Span) -> Range {
+    let start = Position::new(
+        (span.start.row - 1) as u32,
+        (span.start.col - 1) as u32,
+    );
+    let end = Position::new(
+        (span.end.row - 1) as u32,
+        (span.end.col - 1) as u32,
+    );
+    Range::new(start, end)
+}
+
+/// Converts a [`tower_lsp::lsp_types::Position`] into a [`slicec::slice_file::Location`].
+pub fn position_to_location(position: Position) -> Location {
+    let row = (position.line + 1) as usize;
+    let col = (position.character + 1) as usize;
+    Location { row, col }
 }


### PR DESCRIPTION
This function adds 2 helper methods for converting between
`slicec::Span` -> `tower_lsp::Range` and `tower_lsp::Position` -> `slicec::Location`
These represent the same concepts, and thankfully we chose different names, so it's not too hard to follow.

It also cleans up `try_into_hover_result`.
Currently, if the user hovers over something with no message to display, we return an `jsonrpc::Error`, which the caller just ignores and converts to `None` anyways. So, I changed the function to just return `None`, instead of creating this intermediate error thing.