### PR TITLE
Added Highlighting for Metadata on Enumerators

### DIFF
--- a/syntaxes/ice.tmLanguage.json
+++ b/syntaxes/ice.tmLanguage.json
@@ -611,6 +611,14 @@
                                     "patterns": [
                                         {"include": "#standard"},
                                         {
+                                            "begin": "(?=\\[)",
+                                            "end": "(?<=])",
+                                            "patterns": [
+                                                {"include": "#standard"},
+                                                {"include": "#metadata.local"}
+                                            ]
+                                        },
+                                        {
                                             "begin": "\\\\?\\b\\w+\\b",
                                             "end": "(?=})|(,)",
                                             "beginCaptures": {


### PR DESCRIPTION
Assuming that https://github.com/zeroc-ice/ice/pull/2642 gets merged in (adds support for metadata on enumerators),
this PR adds highlighting support for metadata on enumerators.

I tested it locally, and everything seemed fine.