### PR TITLE
Cleanup and Diagnostic Fixes

### DIFF
--- a/server/src/configuration.rs
+++ b/server/src/configuration.rs
@@ -13,25 +13,25 @@ pub struct ServerConfig {
     pub built_in_slice_path: String,
 }
 
-/// This struct holds the configuration for a single compilation set.
+/// This struct holds the configuration for a single Slice project.
 #[derive(Debug)]
-pub struct SliceConfig {
+pub struct ProjectConfig {
     /// List of paths that will be passed to the compiler as reference files/directories.
     pub slice_search_paths: Vec<PathBuf>,
     /// Specifies whether to include the built-in Slice files that are bundled with the extension.
     pub include_built_in_slice_files: bool,
 }
 
-impl Default for SliceConfig {
+impl Default for ProjectConfig {
     fn default() -> Self {
-        SliceConfig {
+        ProjectConfig {
             slice_search_paths: vec![],
             include_built_in_slice_files: true,
         }
     }
 }
 
-pub fn compute_slice_options(server_config: &ServerConfig, set_config: &SliceConfig) -> SliceOptions {
+pub fn compute_slice_options(server_config: &ServerConfig, project_config: &ProjectConfig) -> SliceOptions {
     let root_path = &server_config.workspace_root_path;
     let mut slice_options = SliceOptions::default();
     let references = &mut slice_options.references;
@@ -39,11 +39,11 @@ pub fn compute_slice_options(server_config: &ServerConfig, set_config: &SliceCon
     // Add the built-in Slice files (WellKnownTypes, etc.) at the start of the list, if they should be included.
     // Putting them first ensures that any redefinition conflicts will appear in the user's files, and not these.
     // (Since `slicec` parses files in the order that they are provided).
-    if set_config.include_built_in_slice_files {
+    if project_config.include_built_in_slice_files {
         references.push(server_config.built_in_slice_path.clone());
     }
 
-    match set_config.slice_search_paths.as_slice() {
+    match project_config.slice_search_paths.as_slice() {
         // If the user didn't specify any paths, default to using the workspace root.
         [] => references.push(root_path.display().to_string()),
 

--- a/server/src/configuration.rs
+++ b/server/src/configuration.rs
@@ -13,7 +13,7 @@ pub struct ServerConfig {
     pub built_in_slice_path: String,
 }
 
-/// This struct holds the configuration for a single Slice project.
+/// This struct holds configuration that affects a single Slice project.
 #[derive(Debug)]
 pub struct ProjectConfig {
     /// List of paths that will be passed to the compiler as reference files/directories.

--- a/server/src/diagnostic_handler.rs
+++ b/server/src/diagnostic_handler.rs
@@ -5,7 +5,7 @@ use crate::utils::{convert_slice_path_to_uri, span_to_range};
 use crate::{notifications, show_popup};
 
 use slicec::diagnostics::{Diagnostic, DiagnosticLevel, Note};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use tower_lsp::lsp_types::{DiagnosticRelatedInformation, Location, NumberOrString, Url};
 use tower_lsp::Client;
 
@@ -76,29 +76,6 @@ pub fn process_diagnostics(
             publish_map.entry(uri).or_default().push(lsp_diagnostic);
         });
     spanless_diagnostics
-}
-
-/// Clears the diagnostics for all tracked files in the provided projects.
-///
-/// This function iterates over the projects, collects all tracked file URIs,
-/// and then publishes empty diagnostics to clear existing ones for each URI.
-pub async fn clear_diagnostics(client_handle: &Client, projects: &[SliceProject]) {
-    let mut all_tracked_files = HashSet::new();
-    for project in projects.iter() {
-        project
-            .compilation_data
-            .files
-            .keys()
-            .filter_map(convert_slice_path_to_uri)
-            .for_each(|uri| {
-                all_tracked_files.insert(uri);
-            });
-    }
-
-    // Clear diagnostics for each tracked file
-    for uri in all_tracked_files {
-        client_handle.publish_diagnostics(uri, vec![], None).await;
-    }
 }
 
 // A helper function that converts a slicec diagnostic into an lsp diagnostics

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -184,7 +184,7 @@ impl LanguageServer for SliceLanguageServer {
     }
 
     async fn initialized(&self, _: InitializedParams) {
-        let msg = "Slice Language Server has finished initialized.";
+        let msg = "Slice Language Server has fully initialized.";
         self.client_handle.log_message(MessageType::INFO, msg).await;
 
         // Now that the server and client are fully initialized, it's safe to compile and publish any diagnostics.

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -34,11 +34,16 @@ async fn main() {
 }
 
 struct SliceLanguageServer {
+    /// Provides a handle for communicating back to the client that is connected to this server.
     client_handle: Client,
+    /// Stores all of this server's state.
     server_state: Mutex<ServerState>,
 }
 
 impl SliceLanguageServer {
+    /// Create a new language server that is connected to the provided language client.
+    ///
+    /// This method only creates the server; no networking or further initialization is performed.
     pub fn new(client_handle: tower_lsp::Client) -> Self {
         let server_state = Mutex::new(ServerState::default());
         Self { client_handle, server_state }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 use crate::configuration::compute_slice_options;
-use crate::diagnostic_handler::{clear_diagnostics, process_diagnostics, publish_diagnostics_for_set};
+use crate::diagnostic_handler::{clear_diagnostics, process_diagnostics, publish_diagnostics_for_project};
 use crate::hover::get_hover_message;
 use crate::jump_definition::get_definition_span;
 use crate::notifications::{ShowNotification, ShowNotificationParams};
@@ -16,12 +16,12 @@ use tower_lsp::{Client, LanguageServer, LspService, Server};
 use utils::{convert_slice_path_to_uri, span_to_range, url_to_sanitized_file_path};
 
 mod configuration;
-mod configuration_set;
 mod diagnostic_handler;
 mod hover;
 mod jump_definition;
 mod notifications;
 mod server_state;
+mod slice_project;
 mod utils;
 
 #[tokio::main]
@@ -29,19 +29,19 @@ async fn main() {
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 
-    let (service, socket) = LspService::new(Backend::new);
+    let (service, socket) = LspService::new(SliceLanguageServer::new);
     Server::new(stdin, stdout, socket).serve(service).await;
 }
 
-struct Backend {
-    client: Client,
+struct SliceLanguageServer {
+    client_handle: Client,
     server_state: Mutex<ServerState>,
 }
 
-impl Backend {
-    pub fn new(client: tower_lsp::Client) -> Self {
+impl SliceLanguageServer {
+    pub fn new(client_handle: tower_lsp::Client) -> Self {
         let server_state = Mutex::new(ServerState::default());
-        Self { client, server_state }
+        Self { client_handle, server_state }
     }
 
     fn capabilities() -> ServerCapabilities {
@@ -77,19 +77,19 @@ impl Backend {
     }
 
     async fn handle_file_change(&self, file_path: &Path) {
-        self.client
+        self.client_handle
             .log_message(MessageType::INFO, format!("File '{}' changed", file_path.display()))
             .await;
 
         let mut server_guard = self.server_state.lock().await;
-        let ServerState { configuration_sets, server_config } = server_guard.deref_mut();
+        let ServerState { slice_projects, server_config } = server_guard.deref_mut();
 
         let mut publish_map = HashMap::new();
         let mut diagnostics = Vec::new();
 
-        // Process each configuration set that contains the changed file.
-        for set in configuration_sets.iter_mut().filter(|set| {
-            compute_slice_options(server_config, &set.slice_config)
+        // Process each project that contains the changed file.
+        for project in slice_projects.iter_mut().filter(|project| {
+            compute_slice_options(server_config, &project.project_config)
                 .references
                 .into_iter()
                 .any(|f| {
@@ -97,12 +97,12 @@ impl Backend {
                     key_path == file_path || file_path.starts_with(key_path)
                 })
         }) {
-            // `trigger_compilation` compiles the configuration set's files and returns any diagnostics.
-            diagnostics.extend(set.trigger_compilation(server_config));
+            // `trigger_compilation` compiles the project's files and returns any diagnostics.
+            diagnostics.extend(project.trigger_compilation(server_config));
 
             // Update publish_map with files to be updated.
             publish_map.extend(
-                set.compilation_data
+                project.compilation_data
                     .files
                     .keys()
                     .filter_map(convert_slice_path_to_uri)
@@ -119,7 +119,7 @@ impl Backend {
         let spanless_diagnostics = process_diagnostics(diagnostics, &mut publish_map);
         for diagnostic in spanless_diagnostics {
             show_popup(
-                &self.client,
+                &self.client_handle,
                 diagnostic.message(),
                 notifications::MessageType::Error,
             )
@@ -127,48 +127,48 @@ impl Backend {
         }
 
         // Publish the diagnostics for each file.
-        self.client
+        self.client_handle
             .log_message(
                 MessageType::INFO,
-                "Publishing diagnostics for all configuration sets.",
+                "Publishing diagnostics for all projects.",
             )
             .await;
 
         for (uri, lsp_diagnostics) in publish_map {
-            self.client
+            self.client_handle
                 .publish_diagnostics(uri, lsp_diagnostics, None)
                 .await;
         }
     }
 
     /// Triggers and compilation and publishes any diagnostics that are reported.
-    /// It does this for all configuration sets.
+    /// It does this for all projects.
     pub async fn compile_and_publish_diagnostics(&self) {
         let mut server_guard = self.server_state.lock().await;
-        let ServerState { configuration_sets, server_config } = server_guard.deref_mut();
+        let ServerState { slice_projects, server_config } = server_guard.deref_mut();
 
-        self.client
+        self.client_handle
             .log_message(
                 MessageType::INFO,
-                "Publishing diagnostics for all configuration sets.",
+                "Publishing diagnostics for all projects.",
             )
             .await;
-        for configuration_set in configuration_sets.iter_mut() {
+        for project in slice_projects.iter_mut() {
             // Trigger a compilation and get any diagnostics that were reported during it.
-            let diagnostics = configuration_set.trigger_compilation(server_config);
+            let diagnostics = project.trigger_compilation(server_config);
             // Publish those diagnostics.
-            publish_diagnostics_for_set(&self.client, diagnostics, configuration_set).await;
+            publish_diagnostics_for_project(&self.client_handle, diagnostics, project).await;
         }
     }
 }
 
 #[tower_lsp::async_trait]
-impl LanguageServer for Backend {
+impl LanguageServer for SliceLanguageServer {
     async fn initialize(&self, params: InitializeParams) -> tower_lsp::jsonrpc::Result<InitializeResult> {
         let mut server_guard = self.server_state.lock().await;
         server_guard.update_from_initialize_params(params);
 
-        let capabilities = Backend::capabilities();
+        let capabilities = SliceLanguageServer::capabilities();
         Ok(InitializeResult {
             capabilities,
             ..InitializeResult::default()
@@ -185,7 +185,7 @@ impl LanguageServer for Backend {
     }
 
     async fn did_change_configuration(&self, params: DidChangeConfigurationParams) {
-        self.client
+        self.client_handle
             .log_message(MessageType::INFO, "Extension settings changed")
             .await;
 
@@ -195,10 +195,10 @@ impl LanguageServer for Backend {
 
             // When the configuration changes, any of the files in the workspace could be impacted.
             // Therefore, we need to clear the diagnostics for all files and then re-publish them.
-            clear_diagnostics(&self.client, &server_guard.configuration_sets).await;
+            clear_diagnostics(&self.client_handle, &server_guard.slice_projects).await;
 
-            // Update the stored configuration sets from the data provided in the client notification.
-            server_guard.update_configurations_from_params(params);
+            // Update the stored Slice projects from the data provided in the client notification.
+            server_guard.update_projects_from_params(params);
         }
 
         // Trigger a compilation and publish the diagnostics for all files.
@@ -215,13 +215,13 @@ impl LanguageServer for Backend {
         // Convert the URI to a file path and back to a URL to ensure that the URI is formatted correctly for Windows.
         let file_path = url_to_sanitized_file_path(&uri).ok_or_else(Error::internal_error)?;
 
-        // Find the configuration set that contains the file
+        // Find the project that contains the file
         let server_guard = self.server_state.lock().await;
-        let configuration_sets = &server_guard.configuration_sets;
+        let slice_projects = &server_guard.slice_projects;
 
         // Get the definition span and convert it to a GotoDefinitionResponse
-        Ok(configuration_sets.iter().find_map(|set| {
-            let files = &set.compilation_data.files;
+        Ok(slice_projects.iter().find_map(|project| {
+            let files = &project.compilation_data.files;
             files
                 .get(&file_path)
                 .and_then(|file| get_definition_span(file, position))
@@ -241,12 +241,12 @@ impl LanguageServer for Backend {
         // Convert the URI to a file path and back to a URL to ensure that the URI is formatted correctly for Windows.
         let file_path = url_to_sanitized_file_path(&uri).ok_or_else(Error::internal_error)?;
 
-        // Find the configuration set that contains the file and get the hover info
+        // Find the project that contains the file and get the hover info
         let server_guard = self.server_state.lock().await;
-        let configuration_sets = &server_guard.configuration_sets;
+        let slice_projects = &server_guard.slice_projects;
 
-        Ok(configuration_sets.iter().find_map(|set| {
-            let files = &set.compilation_data.files;
+        Ok(slice_projects.iter().find_map(|project| {
+            let files = &project.compilation_data.files;
             files
                 .get(&file_path)
                 .and_then(|file| get_hover_message(file, position))
@@ -270,9 +270,9 @@ impl LanguageServer for Backend {
     }
 }
 
-pub async fn show_popup(client: &Client, message: String, message_type: notifications::MessageType) {
+pub async fn show_popup(client_handle: &Client, message: String, message_type: notifications::MessageType) {
     let show_notification_params = ShowNotificationParams { message, message_type };
-    client
+    client_handle
         .send_notification::<ShowNotification>(show_notification_params)
         .await;
 }

--- a/server/src/server_state.rs
+++ b/server/src/server_state.rs
@@ -7,9 +7,7 @@ use tower_lsp::lsp_types::{DidChangeConfigurationParams, InitializeParams};
 
 #[derive(Debug, Default)]
 pub struct ServerState {
-    /// This vector contains all of the Slice projects for the language server. Each element is a tuple containing
-    /// `ProjectConfig` and `CompilationState`. The `ProjectConfig` is used to determine which project to use
-    /// when publishing diagnostics. The `CompilationState` is used to retrieve the diagnostics for a given file.
+    /// This vector contains all of the Slice projects for the language server.
     pub slice_projects: Vec<SliceProject>,
     /// Configuration that affects the entire server.
     pub server_config: ServerConfig,

--- a/server/src/server_state.rs
+++ b/server/src/server_state.rs
@@ -1,16 +1,16 @@
 // Copyright (c) ZeroC, Inc.
 
 use crate::configuration::ServerConfig;
-use crate::configuration_set::ConfigurationSet;
+use crate::slice_project::SliceProject;
 use crate::utils::{sanitize_path, url_to_sanitized_file_path};
 use tower_lsp::lsp_types::{DidChangeConfigurationParams, InitializeParams};
 
 #[derive(Debug, Default)]
 pub struct ServerState {
-    /// This vector contains all of the configuration sets for the language server. Each element is a tuple containing
-    /// `SliceConfig` and `CompilationState`. The `SliceConfig` is used to determine which configuration set to use
+    /// This vector contains all of the Slice projects for the language server. Each element is a tuple containing
+    /// `ProjectConfig` and `CompilationState`. The `ProjectConfig` is used to determine which project to use
     /// when publishing diagnostics. The `CompilationState` is used to retrieve the diagnostics for a given file.
-    pub configuration_sets: Vec<ConfigurationSet>,
+    pub slice_projects: Vec<SliceProject>,
     /// Configuration that affects the entire server.
     pub server_config: ServerConfig,
 }
@@ -39,40 +39,38 @@ impl ServerState {
 
         self.server_config = ServerConfig { workspace_root_path, built_in_slice_path };
 
-        // Load any user configuration from the 'slice.configurations' option.
-        let configuration_sets = initialization_options
+        // Load the active Slice projects from the 'slice.configurations' option.
+        let slice_projects = initialization_options
             .as_ref()
             .and_then(|opts| opts.get("configurations"))
             .and_then(|v| v.as_array())
-            .map(|arr| ConfigurationSet::parse_configuration_sets(arr))
+            .map(|arr| SliceProject::parse_slice_projects(arr))
             .unwrap_or_default();
 
-        self.update_configurations(configuration_sets);
+        self.set_projects(slice_projects);
     }
 
-    // Update the configuration sets from the `DidChangeConfigurationParams` notification.
-    pub fn update_configurations_from_params(&mut self, params: DidChangeConfigurationParams) {
-        // Parse the configurations from the notification
-        let configurations = params
+    // Update the active projects from the `DidChangeConfigurationParams` notification.
+    pub fn update_projects_from_params(&mut self, params: DidChangeConfigurationParams) {
+        // Parse the projects from the notification
+        let slice_projects = params
             .settings
             .get("slice")
             .and_then(|v| v.get("configurations"))
             .and_then(|v| v.as_array())
-            .map(|arr| ConfigurationSet::parse_configuration_sets(arr))
+            .map(|arr| SliceProject::parse_slice_projects(arr))
             .unwrap_or_default();
 
-        // Update the configuration sets
-        self.update_configurations(configurations);
+        self.set_projects(slice_projects);
     }
 
-    // Update the configuration sets by replacing it with the new configurations. If there are no configuration sets
-    // after updating, insert the default configuration set.
-    fn update_configurations(&mut self, mut configurations: Vec<ConfigurationSet>) {
-        // Insert the default configuration set if needed
-        if configurations.is_empty() {
-            configurations.push(ConfigurationSet::default());
+    // Sets the currently loaded Slice projects.
+    // If no Slice projects are provided, we insert a default project.
+    fn set_projects(&mut self, mut projects: Vec<SliceProject>) {
+        if projects.is_empty() {
+            projects.push(SliceProject::default());
         }
 
-        self.configuration_sets = configurations;
+        self.slice_projects = projects;
     }
 }


### PR DESCRIPTION
This PR performs some general cleanup of the comments/names used in the Slice Language Server, and also updates how we clear diagnostics.

Previously, we had our own kind of hacky function which would compute all the files we're looking at, and then publish 0 diagnostics to the files, "clearing" it. But this seemed to behave weirdly some of the time.

This function was deleted, and now we just call the built-in `Client::workspace_diagnostic_refresh` function instead.