### PR TITLE
Pin GitHub Actions to SHAs and add Dependabot

### DIFF
--- a/.github/actions/build-language-server/action.yml
+++ b/.github/actions/build-language-server/action.yml
@@ -14,7 +14,7 @@ runs:
   using: "composite"
   steps:
     - name: 📦 Cargo Cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           ~/.cargo/bin/
@@ -30,7 +30,7 @@ runs:
       run: sudo apt update && sudo apt install gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu --yes
       shell: bash
     - name: Rust Toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       with:
         toolchain: stable
         targets: ${{ inputs.target }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directories: ["/", "/.github/actions/*"]
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/vsix.yml
+++ b/.github/workflows/vsix.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Build
         uses: ./.github/actions/build-language-server
@@ -46,7 +46,7 @@ jobs:
           target: ${{ matrix.target }}
 
       - name: Upload language server
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: slice-language-server_${{ matrix.target }}
           path: ./server/target/${{ matrix.target }}/release/${{ matrix.bin }}
@@ -58,10 +58,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Download language server
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: ./server/target
 
@@ -80,7 +80,7 @@ jobs:
           # Print the contents of the directory to make sure everything is in the right place
           find .
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
 
       - name: Install dependencies
         run: npm ci
@@ -92,7 +92,7 @@ jobs:
         id: package-version
         run: echo "VERSION=$(npm pkg get version | jq -r)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: "slice-${{ steps.package-version.outputs.VERSION }}.vsix"
           path: "slice-${{ steps.package-version.outputs.VERSION }}.vsix"


### PR DESCRIPTION
Pins every third-party GitHub Action to a full commit SHA (with the version in a trailing comment) and adds a Dependabot config to keep those pins current, matching the setup used across the other repos.

- Pins all actions in the workflows and the composite action under `.github/actions/` so a moved tag can't change what CI runs.
- Adds a `github-actions` Dependabot block scanning both workflows and the composite action (`directories: ["/", "/.github/actions/*"]`): monthly schedule, 7-day cooldown, and a single catch-all group so updates arrive as one PR.
